### PR TITLE
Add functionality for VCF export

### DIFF
--- a/src/main/groovy/life/qbic/oncostore/controller/VariantController.groovy
+++ b/src/main/groovy/life/qbic/oncostore/controller/VariantController.groovy
@@ -141,12 +141,12 @@ class VariantController {
                             uuid = statusId
                             fileName = file.filename
                             fileSize = file.size
-                            status = Status.processing
+                            status = life.qbic.oncostore.model.Status.processing
                         }
                         def test = repository.save(newStatus)
 
                         service.storeVariantsInStore(metadata, variantsToAdd)
-                        repository.updateStatus(test.getId(), Status.finished.toString())
+                        repository.updateStatus(test.getId(), life.qbic.oncostore.model.Status.finished.toString())
                     }
             return HttpResponse.accepted(uri)
         } catch (IOException exception) {

--- a/src/main/groovy/life/qbic/oncostore/database/MariaDBVariantstoreStorage.groovy
+++ b/src/main/groovy/life/qbic/oncostore/database/MariaDBVariantstoreStorage.groovy
@@ -35,6 +35,37 @@ class MariaDBVariantstoreStorage implements VariantstoreStorage {
 
     String insertEnsemblGeneJunction = "INSERT INTO ensembl_has_gene (ensembl_id, gene_id) VALUES (?,?) ON DUPLICATE " + "" + "KEY UPDATE ensembl_id=ensembl_id"
     String insertConsequenceGeneJunction = "INSERT INTO consequence_has_gene (consequence_id, gene_id) VALUES (?,?) "+ "ON DUPLICATE KEY UPDATE consequence_id=consequence_id"
+    String selectVariantsWithConsequencesAndGenotypes = """SELECT variant.id as varid, variant.chr as varchr, variant.start as varstart, 
+variant.end as varend, variant.ref as varref, variant.obs as varobs, variant.issomatic as varsomatic, variant.uuid as
+ varuuid, variant.databaseidentifier as vardbid, consequence.*,vcfinfo.*, gene.id as geneindex, gene.geneid as geneid FROM 
+ variant INNER JOIN sample_has_variant ON variant_id = variant.id INNER JOIN vcfinfo ON vcfinfo.id=sample_has_variant
+ .vcfinfo_id INNER JOIN variant_has_consequence 
+ ON variant.id = variant_has_consequence.variant_id INNER JOIN genotype ON genotype.id=sample_has_variant.genotype_id
+  JOIN consequence on variant_has_consequence.consequence_id 
+ = consequence.id INNER JOIN consequence_has_gene on consequence_has_gene.consequence_id = consequence.id INNER JOIN 
+ gene on gene.id=consequence_has_gene.gene_id;"""
+
+    String selectVariantsWithConsequencesAndVcfInfo = """SELECT variant.id as varid, variant.chr as varchr, variant.start as varstart, 
+variant.end as varend, variant.ref as varref, variant.obs as varobs, variant.issomatic as varsomatic, variant.uuid as
+ varuuid, variant.databaseidentifier as vardbid, consequence.*, vcfinfo.*, gene.id as geneindex, gene.geneid as geneid FROM 
+ variant INNER JOIN sample_has_variant ON variant_id = variant.id INNER JOIN vcfinfo ON vcfinfo.id=sample_has_variant
+ .vcfinfo_id INNER JOIN variant_has_consequence 
+ ON variant.id = variant_has_consequence.variant_id INNER JOIN consequence on variant_has_consequence.consequence_id 
+ = consequence.id INNER JOIN consequence_has_gene on consequence_has_gene.consequence_id = consequence.id INNER JOIN 
+ gene on gene.id=consequence_has_gene.gene_id;"""
+
+    String selectVariantsWithConsequences = """SELECT variant.id as varid, variant.chr as varchr, variant.start as varstart, 
+variant.end as varend, variant.ref as varref, variant.obs as varobs, variant.issomatic as varsomatic, variant.uuid as
+ varuuid, variant.databaseidentifier as vardbid, consequence.*, gene.id as geneindex, gene.geneid as geneid FROM 
+ variant INNER JOIN variant_has_consequence 
+ ON variant.id = variant_has_consequence.variant_id INNER JOIN consequence on variant_has_consequence.consequence_id 
+ = consequence.id INNER JOIN consequence_has_gene on consequence_has_gene.consequence_id = consequence.id INNER JOIN 
+ gene on gene.id=consequence_has_gene.gene_id;"""
+
+    String selectVariants = """SELECT variant.id as varid, variant.chr as varchr, variant.start as varstart, 
+variant.end as varend, variant.ref as varref, variant.obs as varobs, variant.issomatic as varsomatic, variant.uuid as
+ varuuid, variant.databaseidentifier as vardbid FROM variant;"""
+
 
     @Inject
     MariaDBVariantstoreStorage(QBiCDataSource dataSource) {
@@ -170,36 +201,96 @@ class MariaDBVariantstoreStorage implements VariantstoreStorage {
     }
 
     @Override
-    List<Variant> findVariants(@NotNull ListingArguments args, Boolean withConsequences) {
+    List<Variant> findVariants(@NotNull ListingArguments args, Boolean withConsequences, Boolean withVcfInfo, Boolean withGenotypes) {
         sql = new Sql(dataSource.connection)
         try {
             if (args.getChromosome().isPresent() && args.getStartPosition().isPresent()) {
                 return fetchVariantsByChromosomeAndStartPosition(args.getChromosome().get(), args.getStartPosition()
-                        .get(), withConsequences)
+                        .get(), withConsequences, withVcfInfo, withGenotypes)
             }
 
             if (args.getStartPosition().isPresent()) {
-                return fetchVariantsByStartPosition(args.getStartPosition().get(), withConsequences)
+                return fetchVariantsByStartPosition(args.getStartPosition().get(), withConsequences, withVcfInfo, withGenotypes)
             }
 
             if (args.getChromosome().isPresent()) {
-                return fetchVariantsByChromosome(args.getChromosome().get(), withConsequences)
+                return fetchVariantsByChromosome(args.getChromosome().get(), withConsequences, withVcfInfo, withGenotypes)
             }
 
             if (args.getSampleId().isPresent() && args.getGeneId().isPresent()) {
-                return fetchVariantsBySampleAndGeneId(args.getSampleId().get(), args.getGeneId().get(), withConsequences)
+                return fetchVariantsBySampleAndGeneId(args.getSampleId().get(), args.getGeneId().get(), withConsequences, withVcfInfo, withGenotypes)
             }
 
             if (args.getSampleId().isPresent()) {
-                return fetchVariantsBySample(args.getSampleId().get(), withConsequences)
+                return fetchVariantsBySample(args.getSampleId().get(), withConsequences, withVcfInfo, withGenotypes)
             }
 
             if (args.getGeneId().isPresent()) {
-                return fetchVariantsByGeneId(args.getGeneId().get(), withConsequences)
+                return fetchVariantsByGeneId(args.getGeneId().get(), withConsequences, withVcfInfo, withGenotypes)
             }
-            return fetchVariants(withConsequences)
+            return fetchVariants(withConsequences, withVcfInfo, withGenotypes)
         } catch (Exception e) {
             throw new VariantstoreStorageException("Could not fetch variants.", e.printStackTrace())
+        } finally {
+            sql.close()
+        }
+    }
+
+    @Override
+    ReferenceGenome findReferenceGenomeByVariant(Variant variant) {
+        sql = new Sql(dataSource.connection)
+        try {
+
+            def result =
+                    sql.firstRow("SELECT id FROM variant WHERE variant.chr=? and variant.start=? and variant" + "" + ".end=? and variant.ref=? and variant.obs=? and variant.issomatic=?",
+                            [variant.chromosome, variant.startPosition, variant.endPosition, variant.referenceAllele, variant
+                                    .observedAllele, variant.isSomatic])
+
+            def resultReference = sql.firstRow("SELECT * FROM referencegenome INNER JOIN variant_has_referencegenome WHERE variant_has_referencegenome.variant_id = ${result.id}")
+            def referenceGenomeSource = resultReference.get("source") as String
+            def referenceGenomeBuild = resultReference.get("build") as String
+            def referenceGenomeVersion = resultReference.get("version") as String
+            def referenceGenome = new ReferenceGenome(referenceGenomeSource, referenceGenomeBuild, referenceGenomeVersion)
+            return referenceGenome
+        } catch (Exception e) {
+            throw new VariantstoreStorageException("Could not fetch reference genome.", e.fillInStackTrace())
+        } finally {
+            sql.close()
+        }
+    }
+
+    @Override
+    Annotation findAnnotationSoftwareByConsequence(Consequence consequence) {
+        sql = new Sql(dataSource.connection)
+        try {
+
+            def result = sql.firstRow("SELECT id FROM consequence WHERE consequence.allele=? and consequence" + "" +
+                    ".codingchange=? and consequence.transcriptid=? and consequence.transcriptversion=? and" + " " +
+                    "consequence.type=? and consequence.biotype=? and consequence.canonical=? and consequence" + "" +
+                    ".aachange=? and consequence.cdnaposition=? and consequence.cdsposition=? and consequence" + "" +
+                    ".proteinposition=? and consequence.proteinlength=? and consequence.cdnalength=? and consequence"
+                    + ".cdslength=? and consequence.impact=? and consequence.exon=? and consequence.intron=? and " +
+                    "consequence.strand=? and consequence.genesymbol=? and consequence.featuretype=? and consequence"
+                    + ".distance=? and consequence.warnings=?",
+
+                    [consequence.allele, consequence.codingChange, consequence.transcriptId, consequence
+                            .transcriptVersion, consequence.type,
+                     consequence.bioType, consequence.canonical, consequence.aaChange, consequence.cdnaPosition,
+                     consequence.cdsPosition, consequence
+                             .proteinPosition, consequence.proteinLength, consequence.cdnaLength, consequence
+                             .cdsLength, consequence
+                             .impact, consequence.exon, consequence.intron, consequence.strand, consequence
+                             .geneSymbol, consequence.featureType,
+                     consequence.distance, consequence.warnings])
+
+            def resultAnnotation = sql.firstRow("SELECT * FROM annotationsoftware INNER JOIN annotationsoftware_has_consequence WHERE annotationsoftware_has_consequence.consequence_id = ${result.id}")
+            def annotationSoftwareName = resultAnnotation.get("name") as String
+            def annotationSoftwareVersion = resultAnnotation.get("version") as String
+            def annotationSoftwareDoi = resultAnnotation.get("doi") as String
+            def annotationSoftware = new Annotation(annotationSoftwareName, annotationSoftwareVersion, annotationSoftwareDoi)
+            return annotationSoftware
+        } catch (Exception e) {
+            throw new VariantstoreStorageException("Could not fetch annotation software.", e.fillInStackTrace())
         } finally {
             sql.close()
         }
@@ -665,24 +756,22 @@ ensembl.version=$ensemblVersion;""")
         return samples
     }
 
-    private List<Variant> fetchVariants(withConsequences ) {
+    private List<Variant> fetchVariants(withConsequences, withVcInfo, withGenotypes) {
         def result
 
-        if (withConsequences) {
-            result = sql.rows("""SELECT variant.id as varid, variant.chr as varchr, variant.start as varstart, 
-variant.end as varend, variant.ref as varref, variant.obs as varobs, variant.issomatic as varsomatic, variant.uuid as
- varuuid, variant.databaseidentifier as vardbid, consequence.*, gene.id as geneindex, gene.geneid as geneid FROM variant INNER JOIN variant_has_consequence 
- ON variant.id = variant_has_consequence.variant_id INNER JOIN consequence on variant_has_consequence.consequence_id 
- = consequence.id INNER JOIN consequence_has_gene on consequence_has_gene.consequence_id = consequence.id INNER JOIN 
- gene on gene.id=consequence_has_gene.gene_id;""")
+        if (withConsequences & withGenotypes) {
+            // we will fetch VcfInfo information as well since this case is always VCF output format
+            result = sql.rows(selectVariantsWithConsequencesAndGenotypes)
+        } else if (withConsequences) {
+            if (withVcInfo) {
+                result = sql.rows(selectVariantsWithConsequencesAndVcfInfo)
+            } else {
+                result = sql.rows(selectVariantsWithConsequences)
+            }
+        } else {
+            result = sql.rows(selectVariants)
         }
-        else {
-        result = sql.rows("""SELECT variant.id as varid, variant.chr as varchr, variant.start as varstart, 
-variant.end as varend, variant.ref as varref, variant.obs as varobs, variant.issomatic as varsomatic, variant.uuid as
- varuuid, variant.databaseidentifier as vardbid FROM variant;""")
-        }
-
-        return parseVariantQueryResult(result, withConsequences)
+        return parseVariantQueryResult(result, withConsequences, withVcInfo, withGenotypes)
     }
 
     private List<Gene> fetchGenes() {
@@ -725,116 +814,112 @@ $startPosition AND variant.end <= $endPosition;""")
         return samples
     }
 
-    private List<Variant> fetchVariantsByChromosomeAndStartPosition(String chromosome, BigInteger start, Boolean withConsequences) {
+    private List<Variant> fetchVariantsByChromosomeAndStartPosition(String chromosome, BigInteger start, Boolean withConsequences, Boolean withVcInfo, Boolean withGenotypes) {
         def result
 
-        if (withConsequences) {
-            result = sql.rows("""SELECT variant.id as varid, variant.chr as varchr, variant.start as varstart, 
-variant.end as varend, variant.ref as varref, variant.obs as varobs, variant.issomatic as varsomatic, variant.uuid as
- varuuid, variant.databaseidentifier as vardbid, consequence.*, gene.id as geneindex, gene.geneid as geneid FROM variant INNER JOIN variant_has_consequence 
- ON variant.id = variant_has_consequence.variant_id INNER JOIN consequence on variant_has_consequence.consequence_id 
- = consequence.id INNER JOIN consequence_has_gene on consequence_has_gene.consequence_id = consequence.id INNER JOIN 
- gene on gene.id=consequence_has_gene.gene_id WHERE variant.chr=$chromosome AND variant.start=$start;""")
+        if (withConsequences & withGenotypes) {
+            // we will fetch VcfInfo information as well since this case is always VCF output format
+            result = sql.rows(selectVariantsWithConsequencesAndGenotypes.replace(";", " WHERE variant.chr='${chromosome}' AND variant.start=$start;"))
+        } else if (withConsequences) {
+            if (withVcInfo) {
+                result = sql.rows(selectVariantsWithConsequencesAndVcfInfo.replace(";", " WHERE variant.chr='${chromosome}' AND variant.start=$start;"))
+            } else {
+                result = sql.rows(selectVariantsWithConsequences.replace(";", " WHERE variant.chr='${chromosome}' AND variant.start=$start;"))
+            }
+        } else {
+            result = sql.rows(selectVariants.replace(";", " WHERE variant.chr='${chromosome}' AND variant.start=$start;"))
         }
-        else {
-            result = sql.rows("""SELECT variant.id as varid, variant.chr as varchr, variant.start as varstart, 
-variant.end as varend, variant.ref as varref, variant.obs as varobs, variant.issomatic as varsomatic, variant.uuid as
- varuuid, variant.databaseidentifier as vardbid FROM variant WHERE variant.chr=$chromosome AND variant.start=$start;""")
-        }
-
-        return parseVariantQueryResult(result, withConsequences)
+        return parseVariantQueryResult(result, withConsequences, withVcInfo, withGenotypes)
     }
 
-    private List<Variant> fetchVariantsByChromosome(String chromosome, Boolean withConsequences) {
+    private List<Variant> fetchVariantsByChromosome(String chromosome, Boolean withConsequences, Boolean withVcInfo, Boolean withGenotypes) {
         def result
-        if (withConsequences) {
-            result = sql.rows("""SELECT variant.id as varid, variant.chr as varchr, variant.start as varstart, 
-variant.end as varend, variant.ref as varref, variant.obs as varobs, variant.issomatic as varsomatic, variant.uuid as
- varuuid, variant.databaseidentifier as vardbid, consequence.*, gene.id as geneindex, gene.geneid as geneid FROM variant INNER JOIN variant_has_consequence 
- ON variant.id = variant_has_consequence.variant_id INNER JOIN consequence on variant_has_consequence.consequence_id 
- = consequence.id INNER JOIN consequence_has_gene on consequence_has_gene.consequence_id = consequence.id INNER JOIN 
- gene on gene.id=consequence_has_gene.gene_id WHERE variant.chr=$chromosome;""")
+
+        if (withConsequences & withGenotypes) {
+            // we will fetch VcfInfo information as well since this case is always VCF output format
+            result = sql.rows(selectVariantsWithConsequencesAndGenotypes.replace(";", " WHERE variant.chr='${chromosome}';"))
+        } else if (withConsequences) {
+            if (withVcInfo) {
+                result = sql.rows(selectVariantsWithConsequencesAndVcfInfo.replace(";", " WHERE variant.chr='${chromosome}';"))
+            } else {
+                result = sql.rows(selectVariantsWithConsequences.replace(";", " WHERE variant.chr='${chromosome}';"))
+            }
+        } else {
+            result = sql.rows(selectVariants.replace(";", " WHERE variant.chr='${chromosome}';"))
         }
-        else {
-            result = sql.rows("""SELECT variant.id as varid, variant.chr as varchr, variant.start as varstart, 
-variant.end as varend, variant.ref as varref, variant.obs as varobs, variant.issomatic as varsomatic, variant.uuid as
- varuuid, variant.databaseidentifier as vardbid FROM variant WHERE variant.chr=$chromosome;""")
-        }
-        return parseVariantQueryResult(result, withConsequences)
+        return parseVariantQueryResult(result, withConsequences, withVcInfo, withGenotypes)
     }
 
-    private List<Variant> fetchVariantsByStartPosition(BigInteger start, Boolean withConsequences) {
+    private List<Variant> fetchVariantsByStartPosition(BigInteger start, Boolean withConsequences, Boolean withVcInfo, Boolean withGenotypes) {
         def result
-        if (withConsequences) {
-            result = sql.rows("""SELECT variant.id as varid, variant.chr as varchr, variant.start as varstart, 
-variant.end as varend, variant.ref as varref, variant.obs as varobs, variant.issomatic as varsomatic, variant.uuid as
- varuuid, variant.databaseidentifier as vardbid, consequence.*, gene.id as geneindex, gene.geneid as geneid FROM variant INNER JOIN variant_has_consequence 
- ON variant.id = variant_has_consequence.variant_id INNER JOIN consequence on variant_has_consequence.consequence_id 
- = consequence.id INNER JOIN consequence_has_gene on consequence_has_gene.consequence_id = consequence.id INNER JOIN 
- gene on gene.id=consequence_has_gene.gene_id WHERE variant.start=$start;""")
+
+        if (withConsequences & withGenotypes) {
+            // we will fetch VcfInfo information as well since this case is always VCF output format
+            result = sql.rows(selectVariantsWithConsequencesAndGenotypes.replace(";", " variant.start=$start;"))
+        } else if (withConsequences) {
+            if (withVcInfo) {
+                result = sql.rows(selectVariantsWithConsequencesAndVcfInfo.replace(";", " variant.start=$start;"))
+            } else {
+                result = sql.rows(selectVariantsWithConsequences.replace(";", " variant.start=$start;"))
+            }
+        } else {
+            result = sql.rows(selectVariants.replace(";", " variant.start=$start;"))
         }
-        else {
-            result = sql.rows("""SELECT variant.id as varid, variant.chr as varchr, variant.start as varstart, 
-variant.end as varend, variant.ref as varref, variant.obs as varobs, variant.issomatic as varsomatic, variant.uuid as
- varuuid, variant.databaseidentifier as vardbid FROM variant WHERE variant.start=$start;""")
-        }
-        return parseVariantQueryResult(result, withConsequences)
+        return parseVariantQueryResult(result, withConsequences, withVcInfo, withGenotypes)
     }
 
-    private List<Variant> fetchVariantsBySample(String sampleId, Boolean withConsequences) {
+    private List<Variant> fetchVariantsBySample(String sampleId, withConsequences, withVcInfo, withGenotypes) {
         def result
-        if (withConsequences) {
-            result = sql.rows("""SELECT variant.id as varid, variant.chr as varchr, variant.start as varstart, 
-variant.end as varend, variant.ref as varref, variant.obs as varobs, variant.issomatic as varsomatic, variant.uuid as
- varuuid, variant.databaseidentifier as vardbid, consequence.*, gene.id as geneindex, gene.geneid as geneid FROM variant INNER JOIN variant_has_consequence 
- ON variant.id = variant_has_consequence.variant_id INNER JOIN consequence on variant_has_consequence.consequence_id 
- = consequence.id INNER JOIN consequence_has_gene on consequence_has_gene.consequence_id = consequence.id INNER JOIN 
- gene on gene.id=consequence_has_gene.gene_id WHERE Sample_identifier=$sampleId;""")
+
+        if (withConsequences & withGenotypes) {
+            // we will fetch VcfInfo information as well since this case is always VCF output format
+            result = sql.rows(selectVariantsWithConsequencesAndGenotypes.replace(";", " WHERE Sample_identifier='${sampleId}';"))
+        } else if (withConsequences) {
+            if (withVcInfo) {
+                result = sql.rows(selectVariantsWithConsequencesAndVcfInfo.replace(";", " WHERE Sample_identifier='${sampleId}';"))
+            } else {
+                result = sql.rows(selectVariantsWithConsequences.replace(";", " WHERE Sample_identifier='${sampleId}';"))
+            }
+        } else {
+            result = sql.rows(selectVariants.replace(";", " WHERE Sample_identifier='${sampleId}';"))
         }
-        else {
-            result = sql.rows("""SELECT variant.id as varid, variant.chr as varchr, variant.start as varstart, 
-variant.end as varend, variant.ref as varref, variant.obs as varobs, variant.issomatic as varsomatic, variant.uuid as
- varuuid, variant.databaseidentifier as vardbid FROM variant WHERE Sample_identifier=$sampleId;""")
-        }
-        return parseVariantQueryResult(result, withConsequences)
+        return parseVariantQueryResult(result, withConsequences, withVcInfo, withGenotypes)
     }
 
-    private List<Variant> fetchVariantsBySampleAndGeneId(String sampleId, String geneId, Boolean withConsequences) {
+    private List<Variant> fetchVariantsBySampleAndGeneId(String sampleId, String geneId, Boolean withConsequences, Boolean withVcInfo, Boolean withGenotypes) {
         def result
-        if (withConsequences) {
-            result = sql.rows("""SELECT variant.id as varid, variant.chr as varchr, variant.start as varstart, 
-variant.end as varend, variant.ref as varref, variant.obs as varobs, variant.issomatic as varsomatic, variant.uuid as
- varuuid, variant.databaseidentifier as vardbid, consequence.*, gene.id as geneindex, gene.geneid as geneid FROM variant INNER JOIN variant_has_consequence 
- ON variant.id = variant_has_consequence.variant_id INNER JOIN consequence on variant_has_consequence.consequence_id 
- = consequence.id INNER JOIN consequence_has_gene on consequence_has_gene.consequence_id = consequence.id INNER JOIN 
- gene on gene.id=consequence_has_gene.gene_id where Sample_identifier = 
-$sampleId AND geneid=$geneId;""")
+
+        if (withConsequences & withGenotypes) {
+            // we will fetch VcfInfo information as well since this case is always VCF output format
+            result = sql.rows(selectVariantsWithConsequencesAndGenotypes.replace(";", " where Sample_identifier = '${sampleId}' AND geneid='${geneId}';"))
+        } else if (withConsequences) {
+            if (withVcInfo) {
+                result = sql.rows(selectVariantsWithConsequencesAndVcfInfo.replace(";", " where Sample_identifier = '${sampleId}' AND geneid='${geneId}';"))
+            } else {
+                result = sql.rows(selectVariantsWithConsequences.replace(";", " where Sample_identifier = '${sampleId}' AND geneid='${geneId}';"))
+            }
+        } else {
+            result = sql.rows(selectVariants.replace(";", " where Sample_identifier = '${sampleId}' AND geneid='${geneId}';"))
         }
-        else {
-            result = sql.rows("""SELECT variant.id as varid, variant.chr as varchr, variant.start as varstart, 
-variant.end as varend, variant.ref as varref, variant.obs as varobs, variant.issomatic as varsomatic, variant.uuid as
- varuuid, variant.databaseidentifier as vardbid FROM variant where Sample_identifier = 
-$sampleId AND geneid=$geneId;""")
-        }
-        return parseVariantQueryResult(result, withConsequences)
+        return parseVariantQueryResult(result, withConsequences, withVcInfo, withGenotypes)
     }
 
-    private List<Variant> fetchVariantsByGeneId(String geneId, Boolean withConsequences) {
+    private List<Variant> fetchVariantsByGeneId(String geneId, Boolean withConsequences, Boolean withVcInfo, Boolean withGenotypes) {
         def result
-        if (withConsequences) {
-            result = sql.rows("""SELECT variant.id as varid, variant.chr as varchr, variant.start as varstart, 
-variant.end as varend, variant.ref as varref, variant.obs as varobs, variant.issomatic as varsomatic, variant.uuid as
- varuuid, variant.databaseidentifier as vardbid, consequence.*, gene.id as geneindex, gene.geneid as geneid FROM variant INNER JOIN variant_has_consequence 
- ON variant.id = variant_has_consequence.variant_id INNER JOIN consequence on variant_has_consequence.consequence_id 
- = consequence.id INNER JOIN consequence_has_gene on consequence_has_gene.consequence_id = consequence.id INNER JOIN 
- gene on gene.id=consequence_has_gene.gene_id WHERE geneid=$geneId;""")
+
+        if (withConsequences & withGenotypes) {
+            // we will fetch VcfInfo information as well since this case is always VCF output format
+            result = sql.rows(selectVariantsWithConsequencesAndGenotypes.replace(";", """ WHERE geneid='${geneId}';"""))
+        } else if (withConsequences) {
+            if (withVcInfo) {
+                result = sql.rows(selectVariantsWithConsequencesAndVcfInfo.replace(";", """ WHERE geneid='${geneId}';"""))
+            } else {
+                result = sql.rows(selectVariantsWithConsequences.replace(";", """ WHERE geneid='${geneId}';"""))
+            }
+        } else {
+            result = sql.rows(selectVariants.replace(";", """ WHERE geneid='${geneId}';"""))
         }
-        else {
-            result = sql.rows("""SELECT variant.id as varid, variant.chr as varchr, variant.start as varstart, 
-variant.end as varend, variant.ref as varref, variant.obs as varobs, variant.issomatic as varsomatic, variant.uuid as
- varuuid, variant.databaseidentifier as vardbid FROM variant WHERE geneid=$geneId;""")
-        }
-        return parseVariantQueryResult(result, withConsequences)
+        return parseVariantQueryResult(result, withConsequences, withVcInfo, withGenotypes)
     }
 
     private List<Variant> fetchVariantsForBeaconResponse(String chromosome, BigInteger start,
@@ -1132,7 +1217,8 @@ gene.id = consequence_has_gene.gene_id INNER JOIN consequence on consequence_has
         return gene
     }
 
-    private static Variant convertRowResultToVariant(GroovyRowResult row, Boolean withConsequence) {
+    private static Variant convertRowResultToVariant(GroovyRowResult row, Boolean withConsequences, Boolean
+            withVcfInfo, Boolean withGenotypes) {
         def variant = new Variant()
         variant.setIdentifier(row.get("varuuid") as String)
         variant.setChromosome(row.get("varchr") as String)
@@ -1142,8 +1228,11 @@ gene.id = consequence_has_gene.gene_id INNER JOIN consequence on consequence_has
         variant.setObservedAllele(row.get("varobs") as String)
         variant.setIsSomatic(row.get("varsomatic") as Boolean)
         variant.setDatabaseIdentifier(row.get("vardbid") as String)
-        if (withConsequence) {
+        if (withConsequences) {
             variant.setConsequences([convertRowResultToConsequence(row)])
+        }
+        if (withVcfInfo) {
+            variant.setVcfInfo(convertRowResultToVcfInfo(row))
         }
         return variant
     }
@@ -1176,13 +1265,19 @@ gene.id = consequence_has_gene.gene_id INNER JOIN consequence on consequence_has
         return consequence
     }
 
-    private static List<Variant> parseVariantQueryResult(List<GroovyRowResult> rows, Boolean withConsequence = true) {
-        Map<String, List<Variant>> variantsIdMap = rows.collect { convertRowResultToVariant(it, withConsequence) }
+    private static VcfInfo convertRowResultToVcfInfo(GroovyRowResult row) {
+        def vcfInfo = new VcfInfo()
+        vcfInfo.ancestralAllele = row.get("ancestralallele") as String
+        return vcfInfo
+    }
+
+    private static List<Variant> parseVariantQueryResult(List<GroovyRowResult> rows, Boolean withConsequence = true, withVcfInfo = false, Boolean withGenotypes = false) {
+        Map<String, List<Variant>> variantsIdMap = rows.collect { convertRowResultToVariant(it, withConsequence, withVcfInfo, withGenotypes) }
                 .groupBy { it.identifier }
         List<Variant> variants = []
 
         if (!withConsequence) {
-            return variantsIdMap.values().toList() as List<Variant>
+            return variantsIdMap.values().toList().flatten() as List<Variant>
         }
 
         variantsIdMap.each { key, value ->
@@ -1206,40 +1301,9 @@ gene.id = consequence_has_gene.gene_id INNER JOIN consequence on consequence_has
             value[0].consequences = joinedConsequences
             variants.add(value[0])
         }
-        return variants
+        return variants.flatten() as List<Variant>
     }
 }
-
-
-/*
-@Requires(env = "test")
-@Requires(property = "database.schema-uri")
-@Singleton
-class DatabaseInit implements BeanCreatedEventListener<VariantstoreStorage> {
-
-    String schemaUri
-    String dataUri
-
-    DatabaseInit(@Property(name = 'database.schema-uri') schemaUri, @Property(name = 'database.data-uri') dataUri) {
-        this.schemaUri = schemaUri
-        this.dataUri = dataUri
-    }
-
-    VariantstoreStorage onCreated(BeanCreatedEvent<VariantstoreStorage> event) {
-        def sqlStatement = new File(schemaUri).text
-        def insertStatements = new File(dataUri).text
-        MariaDBVariantstoreStorage storage = event.bean
-        setupDatabase(storage.dataSource.connection, sqlStatement)
-        setupDatabase(storage.dataSource.connection, insertStatements)
-        return event.bean
-    }
-
-    private static setupDatabase(Connection connection, String sqlStatement) {
-        Sql sql = new Sql(connection)
-        sql.execute(sqlStatement)
-    }
-
- */
 
 
 

--- a/src/main/groovy/life/qbic/oncostore/model/ReferenceGenome.groovy
+++ b/src/main/groovy/life/qbic/oncostore/model/ReferenceGenome.groovy
@@ -29,4 +29,9 @@ class ReferenceGenome {
     String getVersion() {
         return version
     }
+
+    @Override
+    String toString() {
+        return "${build}.${version}"
+    }
 }

--- a/src/main/groovy/life/qbic/oncostore/model/Variant.groovy
+++ b/src/main/groovy/life/qbic/oncostore/model/Variant.groovy
@@ -160,7 +160,10 @@ class Variant implements SimpleVariantContext, Comparable{
     }
 
     String toVcfFormat() {
-        return new StringBuilder().append(chromosome + "\t").append(startPosition + "\t").append(referenceAllele + "\t").append(observedAllele + "\t")
+        def vcfInfo = vcfInfo.toVcfFormat() ?: '.'
+        return new StringBuilder().append(chromosome + "\t").append(startPosition + "\t").append(databaseIdentifier +
+                "\t").append(referenceAllele + "\t").append(observedAllele + "\t").append("." + "\t").append("." +
+                "\t").append(vcfInfo)
     }
 
 }

--- a/src/main/groovy/life/qbic/oncostore/model/VcfInfo.groovy
+++ b/src/main/groovy/life/qbic/oncostore/model/VcfInfo.groovy
@@ -2,6 +2,7 @@ package life.qbic.oncostore.model
 
 import htsjdk.variant.variantcontext.CommonInfo
 import htsjdk.variant.vcf.VCFConstants
+import life.qbic.oncostore.util.VcfConstants
 
 class VcfInfo {
 
@@ -9,7 +10,7 @@ class VcfInfo {
     // http://samtools.github.io/hts-specs/ (VCF 4.1 and 4.2)
     String ancestralAllele
     List<Integer> alleleCount
-    List<Float> alleleFreq
+    List<Float> alleleFrequency
     Integer numberAlleles
     Integer baseQuality // RMS base quality
     String cigar
@@ -26,11 +27,13 @@ class VcfInfo {
     Boolean somatic
     Boolean validated
 
+    VcfInfo() {}
+
     VcfInfo(CommonInfo commonInfo) {
         //TODO check if that isn`t AA (amino acid) annotation?
         this.ancestralAllele = commonInfo.getAttributeAsString(VCFConstants.ANCESTRAL_ALLELE_KEY,"")
         this.alleleCount = commonInfo.getAttributeAsIntList(VCFConstants.ALLELE_COUNT_KEY, -1)
-        this.alleleFreq = commonInfo.getAttribute(VCFConstants.ALLELE_FREQUENCY_KEY) as List<Float>
+        this.alleleFrequency = commonInfo.getAttribute(VCFConstants.ALLELE_FREQUENCY_KEY) as List<Float>
         this.numberAlleles = commonInfo.getAttributeAsInt(VCFConstants.ALLELE_NUMBER_KEY, -1)
         this.baseQuality = commonInfo.getAttributeAsInt(VCFConstants.RMS_BASE_QUALITY_KEY, -1)
         this.cigar = commonInfo.getAttributeAsString(VCFConstants.CIGAR_KEY, "")
@@ -56,8 +59,8 @@ class VcfInfo {
         return alleleCount
     }
 
-    float getAlleleFreq() {
-        return alleleFreq
+    float getAlleleFrequency() {
+        return alleleFrequency
     }
 
     Integer getNumberAlleles() {
@@ -119,4 +122,16 @@ class VcfInfo {
     Boolean getValidated() {
         return validated
     }
+
+    String toVcfFormat() {
+        def vcfInfoString = new StringJoiner(VcfConstants.PROPERTY_DELIMITER)
+        this.properties.each { it ->
+            if (it.key != "class" & it.value != null) {
+                def name = it.key.toString().toUpperCase() as VcfConstants.VcfInfoAbbreviations
+                vcfInfoString.add("${name.getTag()}${VcfConstants.PROPERTY_DEFINITION_STRING}${it.value.toString()}")
+            }
+        }
+        return vcfInfoString
+    }
+
 }

--- a/src/main/groovy/life/qbic/oncostore/parser/MetadataContext.groovy
+++ b/src/main/groovy/life/qbic/oncostore/parser/MetadataContext.groovy
@@ -8,13 +8,13 @@ import life.qbic.oncostore.model.Sample
 
 class MetadataContext {
 
-    boolean isSomatic
-    VariantCaller variantCalling
-    Annotation variantAnnotation
-    ReferenceGenome referenceGenome
-    Case patient
-    Sample sample
-    List<String> vcfFiles
+    final boolean isSomatic
+    final VariantCaller variantCalling
+    final Annotation variantAnnotation
+    final ReferenceGenome referenceGenome
+    final Case patient
+    final Sample sample
+    final List<String> vcfFiles
 
     MetadataContext() {}
 

--- a/src/main/groovy/life/qbic/oncostore/parser/MetadataContext.groovy
+++ b/src/main/groovy/life/qbic/oncostore/parser/MetadataContext.groovy
@@ -14,18 +14,14 @@ class MetadataContext {
     final ReferenceGenome referenceGenome
     final Case patient
     final Sample sample
-    final List<String> vcfFiles
 
-    MetadataContext() {}
-
-    MetadataContext(boolean isSomatic, VariantCaller variantCalling, Annotation variantAnnotation, ReferenceGenome referenceGenome, Case patient, Sample sample, List<String> vcfFiles) {
+    MetadataContext(boolean isSomatic, VariantCaller variantCalling, Annotation variantAnnotation, ReferenceGenome referenceGenome, Case patient, Sample sample) {
         this.isSomatic = isSomatic
         this.variantCalling = variantCalling
         this.variantAnnotation = variantAnnotation
         this.referenceGenome = referenceGenome
         this.sample = sample
         this.patient = patient
-        this.vcfFiles = vcfFiles
     }
 
     boolean getIsSomatic() {
@@ -50,9 +46,5 @@ class MetadataContext {
 
     Sample getSample() {
         return sample
-    }
-
-    List<String> getVcfFiles() {
-        return vcfFiles
     }
 }

--- a/src/main/groovy/life/qbic/oncostore/parser/MetadataContext.groovy
+++ b/src/main/groovy/life/qbic/oncostore/parser/MetadataContext.groovy
@@ -8,13 +8,15 @@ import life.qbic.oncostore.model.Sample
 
 class MetadataContext {
 
-    final boolean isSomatic
-    final VariantCaller variantCalling
-    final Annotation variantAnnotation
-    final ReferenceGenome referenceGenome
-    final Case patient
-    final Sample sample
-    final List<String> vcfFiles
+    boolean isSomatic
+    VariantCaller variantCalling
+    Annotation variantAnnotation
+    ReferenceGenome referenceGenome
+    Case patient
+    Sample sample
+    List<String> vcfFiles
+
+    MetadataContext() {}
 
     MetadataContext(boolean isSomatic, VariantCaller variantCalling, Annotation variantAnnotation, ReferenceGenome referenceGenome, Case patient, Sample sample, List<String> vcfFiles) {
         this.isSomatic = isSomatic

--- a/src/main/groovy/life/qbic/oncostore/parser/MetadataReader.groovy
+++ b/src/main/groovy/life/qbic/oncostore/parser/MetadataReader.groovy
@@ -6,6 +6,7 @@ import life.qbic.oncostore.model.Case
 import life.qbic.oncostore.model.ReferenceGenome
 import life.qbic.oncostore.model.VariantCaller
 import life.qbic.oncostore.model.Sample
+import life.qbic.oncostore.util.AnnotationHandler
 
 
 class MetadataReader {
@@ -15,13 +16,13 @@ class MetadataReader {
     MetadataReader(File file) {
         def slurper = new JsonSlurper()
         def jsonContent = slurper.parse(file)
-        this.metadataContext = new MetadataContext(parseIsSomatic(jsonContent), parseCallingSoftware(jsonContent), parseAnnotationSoftware(jsonContent), parseReferenceGenome(jsonContent), parseCase(jsonContent), parseSample(jsonContent), parseVcfFiles(jsonContent))
+        this.metadataContext = new MetadataContext(parseIsSomatic(jsonContent), parseCallingSoftware(jsonContent), parseAnnotationSoftware(jsonContent), parseReferenceGenome(jsonContent), parseCase(jsonContent), parseSample(jsonContent))
     }
 
     MetadataReader(String content) {
         def slurper = new JsonSlurper()
         def jsonContent = slurper.parseText(content)
-        this.metadataContext = new MetadataContext(parseIsSomatic(jsonContent), parseCallingSoftware(jsonContent), parseAnnotationSoftware(jsonContent), parseReferenceGenome(jsonContent), parseCase(jsonContent), parseSample(jsonContent), parseVcfFiles(jsonContent))
+        this.metadataContext = new MetadataContext(parseIsSomatic(jsonContent), parseCallingSoftware(jsonContent), parseAnnotationSoftware(jsonContent), parseReferenceGenome(jsonContent), parseCase(jsonContent), parseSample(jsonContent))
     }
 
     MetadataContext getMetadataContext() {
@@ -33,7 +34,12 @@ class MetadataReader {
     }
 
     static Annotation parseAnnotationSoftware(jsonContent) {
-        return new Annotation(jsonContent.variant_annotation.name, jsonContent.variant_annotation.version, jsonContent.variant_annotation.doi)
+        def name = jsonContent.variant_annotation.name as String
+        def version = jsonContent.variant_annotation.version
+        def doi = jsonContent.variant_annotation.doi
+
+        assert name.toUpperCase() in AnnotationHandler.AnnotationTools.values().collect{value -> value.name()}
+        return new Annotation(name, version, doi)
     }
 
     static VariantCaller parseCallingSoftware(jsonContent) {
@@ -50,9 +56,5 @@ class MetadataReader {
 
     static Sample parseSample(jsonContent) {
         return new Sample(jsonContent.sample.identifier, jsonContent.sample.cancerEntity)
-    }
-
-    static List<String> parseVcfFiles(jsonContent) {
-        return jsonContent.vcf_files
     }
 }

--- a/src/main/groovy/life/qbic/oncostore/service/VariantstoreInformationCenter.groovy
+++ b/src/main/groovy/life/qbic/oncostore/service/VariantstoreInformationCenter.groovy
@@ -82,13 +82,6 @@ class VariantstoreInformationCenter implements VariantstoreService{
         return storage.findSamples(args)
     }
 
-
-    @Override
-    @Transactional
-    List<Variant> getVariantsForSpecifiedProperties(@NotNull ListingArguments args, Boolean withConsequences) {
-        return storage.findVariants(args, withConsequences, false, false)
-    }
-
     @Override
     @Transactional
     List<Gene> getGenesForSpecifiedProperties(@NotNull ListingArguments args) {
@@ -97,25 +90,18 @@ class VariantstoreInformationCenter implements VariantstoreService{
 
     @Override
     @Transactional
-    String getVcfContentForVariants(List<Variant> variants, Boolean withConsequences, MetadataContext metadata) {
+    String getVcfContentForVariants(List<Variant> variants, Boolean withConsequences, String referenceGenome, String annotationSoftware) {
         // order variants by position in order to get valid VCF file
         return VariantExporter.exportVariantsToVCF(variants.sort { a, b -> (a.chromosome?.isInteger() ? a.chromosome
                 .toInteger() : a.chromosome) <=> (b.chromosome?.isInteger() ? b.chromosome.toInteger() : b
-                .chromosome) ?: a.startPosition <=> b.startPosition }, withConsequences, metadata) }
+                .chromosome) ?: a.startPosition <=> b.startPosition }, withConsequences, referenceGenome, annotationSoftware) }
 
     @Override
     @Transactional
-    List getVariantsAndMetadataForExport(ListingArguments args, Boolean withConsequences, Boolean withGenotypes) {
-        def variants = storage.findVariants(args, withConsequences, true, withGenotypes)
-        def metadata = new MetadataContext()
-        def referenceGenome = storage.findReferenceGenomeByVariant(variants.get(0))
-        metadata.referenceGenome = referenceGenome
-
-        if (withConsequences) {
-            def annotationSoftware = storage.findAnnotationSoftwareByConsequence(variants.get(0).consequences.get(0))
-            metadata.variantAnnotation = annotationSoftware
-        }
-        return [variants, metadata]
+    List<Variant> getVariantsForSpecifiedProperties(ListingArguments args, String referenceGenome, Boolean
+            withConsequences, String annotationSoftware, Boolean withVcfInfo, Boolean withGenotypes) {
+        def variants = storage.findVariants(args, referenceGenome, withConsequences, annotationSoftware, withVcfInfo, withGenotypes)
+        return variants
     }
 
     /**

--- a/src/main/groovy/life/qbic/oncostore/service/VariantstoreService.groovy
+++ b/src/main/groovy/life/qbic/oncostore/service/VariantstoreService.groovy
@@ -2,6 +2,7 @@ package life.qbic.oncostore.service
 
 import life.qbic.oncostore.model.*
 import life.qbic.oncostore.parser.EnsemblParser
+import life.qbic.oncostore.parser.MetadataContext
 import life.qbic.oncostore.util.ListingArguments
 
 import javax.inject.Singleton
@@ -23,12 +24,14 @@ interface VariantstoreService {
 
     List<Variant> getVariantsForSpecifiedProperties(ListingArguments args, Boolean withConsequences)
 
+    List getVariantsAndMetadataForExport(ListingArguments args, Boolean withConsequences, Boolean withGenotypes)
+
     List<Gene> getGenesForSpecifiedProperties(ListingArguments args)
 
     BeaconAlleleResponse getBeaconAlleleResponse(String chromosome, BigInteger start,
                                                  String reference, String observed, String assemblyId)
 
-    String getVcfContentForVariants(List<Variant> variants)
+    String getVcfContentForVariants(List<Variant> variants, Boolean withConsequences, MetadataContext metadata)
 
     void storeVariantsInStore(String metadata, List<SimpleVariantContext> variants)
 

--- a/src/main/groovy/life/qbic/oncostore/service/VariantstoreService.groovy
+++ b/src/main/groovy/life/qbic/oncostore/service/VariantstoreService.groovy
@@ -22,16 +22,15 @@ interface VariantstoreService {
 
     List<Sample> getSamplesForSpecifiedProperties(ListingArguments args)
 
-    List<Variant> getVariantsForSpecifiedProperties(ListingArguments args, Boolean withConsequences)
-
-    List getVariantsAndMetadataForExport(ListingArguments args, Boolean withConsequences, Boolean withGenotypes)
+    List<Variant> getVariantsForSpecifiedProperties(ListingArguments args, String referenceGenome, Boolean
+            withConsequences, String annotationSoftware, Boolean withVcfInfo, Boolean withGenotypes)
 
     List<Gene> getGenesForSpecifiedProperties(ListingArguments args)
 
     BeaconAlleleResponse getBeaconAlleleResponse(String chromosome, BigInteger start,
                                                  String reference, String observed, String assemblyId)
 
-    String getVcfContentForVariants(List<Variant> variants, Boolean withConsequences, MetadataContext metadata)
+    String getVcfContentForVariants(List<Variant> variants, Boolean withConsequences, String referenceGenome, String annotationSoftware)
 
     void storeVariantsInStore(String metadata, List<SimpleVariantContext> variants)
 

--- a/src/main/groovy/life/qbic/oncostore/service/VariantstoreStorage.groovy
+++ b/src/main/groovy/life/qbic/oncostore/service/VariantstoreStorage.groovy
@@ -2,6 +2,7 @@ package life.qbic.oncostore.service
 
 import life.qbic.oncostore.database.VariantstoreStorageException
 import life.qbic.oncostore.model.Case
+import life.qbic.oncostore.model.Consequence
 import life.qbic.oncostore.model.Gene
 import life.qbic.oncostore.model.ReferenceGenome
 import life.qbic.oncostore.model.Sample
@@ -33,7 +34,11 @@ interface VariantstoreStorage {
 
     List<Sample> findSamples(@NotNull ListingArguments args)
 
-    List<Variant> findVariants(@NotNull ListingArguments args, Boolean withConsequences)
+    List<Variant> findVariants(@NotNull ListingArguments args, Boolean withConsequences, Boolean withVcfInfo, Boolean withGenotypes)
+
+    Annotation findAnnotationSoftwareByConsequence(Consequence consequence)
+
+    ReferenceGenome findReferenceGenomeByVariant(Variant variant)
 
     List<Gene> findGenes(@NotNull ListingArguments args)
 

--- a/src/main/groovy/life/qbic/oncostore/service/VariantstoreStorage.groovy
+++ b/src/main/groovy/life/qbic/oncostore/service/VariantstoreStorage.groovy
@@ -34,7 +34,8 @@ interface VariantstoreStorage {
 
     List<Sample> findSamples(@NotNull ListingArguments args)
 
-    List<Variant> findVariants(@NotNull ListingArguments args, Boolean withConsequences, Boolean withVcfInfo, Boolean withGenotypes)
+    List<Variant> findVariants(@NotNull ListingArguments args, String referenceGenome, Boolean
+            withConsequences, String annotationSoftware, Boolean withVcfInfo, Boolean withGenotypes)
 
     Annotation findAnnotationSoftwareByConsequence(Consequence consequence)
 

--- a/src/main/groovy/life/qbic/oncostore/util/VariantExporter.groovy
+++ b/src/main/groovy/life/qbic/oncostore/util/VariantExporter.groovy
@@ -8,11 +8,10 @@ class VariantExporter {
     private static Map<String, String> vcfHeaders = [:]
 
     /**
-     * headers for different Variant Call Format versions
-     */
+     * headers for different Variant Call Format versions*/
     static {
-        vcfHeaders['4.1'] = "##fileformat=VCFv4.1 \n##fileDate=%s\n##source=%s\n##reference=%s\nCHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n"
-        vcfHeaders["4.2"] = "##fileformat=VCFv4.2 \n##fileDate=%s\n##source=%s\n##reference=%s\n#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n"
+        vcfHeaders['4.1'] = "##fileformat=VCFv4.1 " + "\n##fileDate=%s\n##source=%s\n##reference=%s\nCHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n"
+        vcfHeaders["4.2"] = "##fileformat=VCFv4.2 " + "\n##fileDate=%s\n##source=%s\n##reference=%s\n#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n"
     }
 
     /**
@@ -20,12 +19,13 @@ class VariantExporter {
      * @param variants the variants to export in VCF
      * @return a VCF content
      */
-    static String exportVariantsToVCF(List<Variant> variants, Boolean withConsequences, MetadataContext metadata) {
+    static String exportVariantsToVCF(List<Variant> variants, Boolean withConsequences, String referenceGenome,
+                                      String annotationSoftware) {
         def vcfContent = new StringBuilder()
         def date = new Date().format('yyyyMMdd')
 
         // allow to choose VCF version
-        def vcfHeader = String.format(vcfHeaders["4.1"], date, 'variantstore', metadata.referenceGenome.toString())
+        def vcfHeader = String.format(vcfHeaders["4.1"], date, 'variantstore', referenceGenome)
         vcfContent.append(vcfHeader)
 
         //determine if SnpEff or VEP
@@ -33,11 +33,10 @@ class VariantExporter {
             vcfContent.append(var.toVcfFormat())
             if (withConsequences) {
                 vcfContent.append(";")
-                if (metadata.variantAnnotation.name == "snpeff") {
+                if (annotationSoftware.toLowerCase() == "snpeff") {
                     vcfContent.append("${AnnotationHandler.AnnotationTools.SNPEFF.tag}=")
                     vcfContent.append(var.consequences.collect { AnnotationHandler.toSnpEff(it) }.join(","))
-                }
-                else {
+                } else {
                     vcfContent.append("${AnnotationHandler.AnnotationTools.VEP.tag}=")
                     vcfContent.append(var.consequences.collect { AnnotationHandler.toVep(it) }.join(","))
                 }

--- a/src/main/groovy/life/qbic/oncostore/util/VariantExporter.groovy
+++ b/src/main/groovy/life/qbic/oncostore/util/VariantExporter.groovy
@@ -1,6 +1,7 @@
 package life.qbic.oncostore.util
 
 import life.qbic.oncostore.model.Variant
+import life.qbic.oncostore.parser.MetadataContext
 
 class VariantExporter {
 
@@ -10,8 +11,8 @@ class VariantExporter {
      * headers for different Variant Call Format versions
      */
     static {
-        vcfHeaders['4.1'] = "##fileformat=VCFv4.1 \n##fileDate=%s\n##source=%s\n##reference=\nCHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n"
-        vcfHeaders["4.2"] = "##fileformat=VCFv4.2 \n##fileDate=%s\n##source=%s\n##reference=\n#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n"
+        vcfHeaders['4.1'] = "##fileformat=VCFv4.1 \n##fileDate=%s\n##source=%s\n##reference=%s\nCHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n"
+        vcfHeaders["4.2"] = "##fileformat=VCFv4.2 \n##fileDate=%s\n##source=%s\n##reference=%s\n#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n"
     }
 
     /**
@@ -19,15 +20,28 @@ class VariantExporter {
      * @param variants the variants to export in VCF
      * @return a VCF content
      */
-    static String exportVariantsToVCF(List<Variant> variants) {
+    static String exportVariantsToVCF(List<Variant> variants, Boolean withConsequences, MetadataContext metadata) {
         def vcfContent = new StringBuilder()
         def date = new Date().format('yyyyMMdd')
-        def vcfHeader = String.format(vcfHeaders["4.1"], date, 'Variantstore')
+
+        // allow to choose VCF version
+        def vcfHeader = String.format(vcfHeaders["4.1"], date, 'variantstore', metadata.referenceGenome.toString())
         vcfContent.append(vcfHeader)
 
+        //determine if SnpEff or VEP
         variants.each { var ->
             vcfContent.append(var.toVcfFormat())
-            vcfContent.append(var.consequences.collect{AnnotationHandler.toSnpEff(it)}.join(","))
+            if (withConsequences) {
+                vcfContent.append(";")
+                if (metadata.variantAnnotation.name == "snpeff") {
+                    vcfContent.append("${AnnotationHandler.AnnotationTools.SNPEFF.tag}=")
+                    vcfContent.append(var.consequences.collect { AnnotationHandler.toSnpEff(it) }.join(","))
+                }
+                else {
+                    vcfContent.append("${AnnotationHandler.AnnotationTools.VEP.tag}=")
+                    vcfContent.append(var.consequences.collect { AnnotationHandler.toVep(it) }.join(","))
+                }
+            }
             vcfContent.append("\n")
         }
         return vcfContent

--- a/src/main/groovy/life/qbic/oncostore/util/VcfConstants.groovy
+++ b/src/main/groovy/life/qbic/oncostore/util/VcfConstants.groovy
@@ -1,0 +1,36 @@
+package life.qbic.oncostore.util
+
+class VcfConstants {
+
+    enum VcfInfoAbbreviations{
+        ANCESTRALALLELE("AA"),
+        ALLELECOUNT("AC"),
+        ALLELEFREQUENCY("AF"),
+        NUMBERALLELES("AN"),
+        BASEQUALITY("BQ"),
+        CIGAR("CIGAR"),
+        DBSNP("DB"),
+        COMBINEDDEPTH("DP"),
+        HAPMAPTWO("H2"),
+        HAPMAPTHREE("H3"),
+        THOUSANDGENOMES("1000G"),
+        ENDPOS("END"),
+        RMS("MQ"),
+        MQZERO("MQ0"),
+        STRANDBIAS("SB"),
+        NUMBERSAMPLES("NS"),
+        SOMATIC("SOMATIC"),
+        VALIDATED("VALIDATED")
+
+        VcfInfoAbbreviations(String tag) {
+            this.tag = tag
+        }
+        private final String tag
+        String getTag() {
+            tag
+        }
+    }
+
+    static final String PROPERTY_DELIMITER = ";"
+    static final String PROPERTY_DEFINITION_STRING = "="
+}


### PR DESCRIPTION
With this it is possible to request variants in VCF format by specifying `format=VCF` as query parameter. Additionally it is still possible to get the variants with or without consequences by specifying `withConsequences={true/false}`. The information from the `INFO` column from the VCF the variants were imported from is fetched and exported by default. This could be tricky if you fetch variants from different sources with different `INFO` information and could lead to invalid VCF files (still have to check that).

One feature that is still missing is the export of corresponding genotypes (`withGenotypes=true`) that are available in the database. I guess this should only be possible for variants that share one or multiple genotypes.