### PR TITLE
Fix Ensembl gene information import

### DIFF
--- a/src/main/groovy/life/qbic/variantstore/database/MariaDBVariantstoreStorage.groovy
+++ b/src/main/groovy/life/qbic/variantstore/database/MariaDBVariantstoreStorage.groovy
@@ -1561,7 +1561,6 @@ annotationsoftware.name='${annotationSoftware}' AND geneid='${geneId}';"""))
 annotationsoftware.name='${annotationSoftware}' AND consequence.genesymbol='${geneName}';"""))
             }
             else {
-                println(selectVariantsWithConsequences.replace(";", """ WHERE referencegenome.build='${referenceGenome}' AND consequence.genesymbol='${geneName}';"""))
                 result = sql.rows(selectVariantsWithConsequences.replace(";", """ WHERE referencegenome.build='${referenceGenome}' AND consequence.genesymbol='${geneName}';"""))
             }
         }
@@ -2024,12 +2023,13 @@ gene.id = consequence_has_gene.gene_id INNER JOIN consequence on consequence_has
     private List<Gene> tryToStoreGeneObjects(List<Gene> genes) {
         Sql sql = requestNewConnection()
         sql.connection.autoCommit = false
-        sql.withBatch("insert INTO gene (symbol, name, biotype, chr, start, end, synonyms, geneid, description, strand, version) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE id=id") {
+        sql.withBatch("insert INTO gene (symbol, name, biotype, chr, start, end, synonyms, geneid, description, strand, version) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE symbol=?, name=?, " + "biotype=?, chr=?, start=?, end=?, synonyms=?, geneid=?, description=?, strand=?, version=?") {
             BatchingPreparedStatementWrapper ps ->
             genes.each { gene ->
                 ps.addBatch([gene.symbol, gene.name, gene.bioType, gene.chromosome, gene.geneStart,
-                             gene.geneEnd, gene.synonyms[0], gene.geneId, gene.description, gene
-                                     .strand, gene.version])
+                             gene.geneEnd, gene.synonyms[0], gene.geneId, gene.description, gene.strand, gene.version,
+                             gene.symbol, gene.name, gene.bioType, gene.chromosome, gene.geneStart,
+                             gene.geneEnd, gene.synonyms[0], gene.geneId, gene.description, gene.strand, gene.version])
             }
         }
 

--- a/src/main/groovy/life/qbic/variantstore/parser/EnsemblParser.groovy
+++ b/src/main/groovy/life/qbic/variantstore/parser/EnsemblParser.groovy
@@ -16,6 +16,8 @@ import life.qbic.variantstore.model.ReferenceGenome
 @Log4j2
 class EnsemblParser {
 
+    private final GENOME_REFERENCE_SOURCE_GRC = "Genome Reference Consortium"
+
     /**
      * The genes
      */
@@ -114,7 +116,7 @@ class EnsemblParser {
         this.genes = genes
         // if the reference genome is specified in the file under #!genome-build we will use this information
         def refernceGenomeToDB = referenceGenomeFromFile ? referenceGenomeFromFile : referenceGenome
-        this.referenceGenome = new ReferenceGenome("Genome Reference Consortium", refernceGenomeToDB,
+        this.referenceGenome = new ReferenceGenome(GENOME_REFERENCE_SOURCE_GRC, refernceGenomeToDB,
         referenceGenomeVersion as String)
         this.version = ensemblVersion ? ensemblVersion.toInteger() : -1
         this.date = updateDate


### PR DESCRIPTION
This fixes issues #41 and #42:
- Use existing `Gene` constructor
- Handle case where Ensembl version is not contained in file name, fix type casting

Additionally this makes sure that the reference genome version is used from file content if available. Further the parsed gene information is added to the corresponding gene if it is already stored in the database, otherwise it is created. 