### PR TITLE
One-Click deployment via docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,10 +21,14 @@ COPY ./mvnw.cmd ${variantstore}/mvnw.cmd
 
 # Compile Variantstore
 RUN cd ${variantstore} && \
-    ./mvnw clean compile
+    ./mvnw clean package
+
+# Allow easier accessibility
+RUN mv ${variantstore}/target/variantstore*-SNAPSHOT.jar \
+    ${variantstore}/target/variantstore.runner.jar
 
 #-----------------------------------------------------#
 #                   Run Variantstore                  #
 #-----------------------------------------------------#
 WORKDIR ${variantstore}
-CMD ./mvnw exec:exec
+# CMD java -jar ./target/variantstore.runner.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,30 @@
+#-----------------------------------------------------#
+#                     System Base                     #
+#-----------------------------------------------------#
 FROM openjdk:8u171-alpine3.7
 RUN apk --no-cache add curl
-COPY target/oncostore*.jar oncostore.jar
-CMD java ${JAVA_OPTS} -jar oncostore.jar
+
+#-----------------------------------------------------#
+#                Install Variantstore                 #
+#-----------------------------------------------------#
+# Define install directory
+ENV variantstore=/root/variantstore
+RUN mkdir ${variantstore}
+
+# Get required files for setup
+COPY ./src ${variantstore}/src
+COPY ./pom.xml ${variantstore}/pom.xml
+COPY ./micronaut-cli.yml ${variantstore}/micronaut-cli.yml
+COPY ./.mvn ${variantstore}/.mvn
+COPY ./mvnw ${variantstore}/mvnw
+COPY ./mvnw.cmd ${variantstore}/mvnw.cmd
+
+# Compile Variantstore
+RUN cd ${variantstore} && \
+    ./mvnw clean compile
+
+#-----------------------------------------------------#
+#                   Run Variantstore                  #
+#-----------------------------------------------------#
+WORKDIR ${variantstore}
+CMD ./mvnw exec:exec

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,9 +13,7 @@ services:
     command: --max_allowed_packet=32505856
     restart: always
     container_name: variantstore_db
-    environment:
-      MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
-      MYSQL_DATABASE: variantstore_db
+    env_file: docker-config.env
     volumes:
      - dbstorage:/data/db
      - ./models/variantstore-model.sql:/docker-entrypoint-initdb.d/variantstore-init.sql:ro
@@ -23,7 +21,7 @@ services:
     ports:
      - 3306:3306
     healthcheck:
-      test: "/usr/bin/mysql --user=root --password='' --database=variantstore_db --execute \"SELECT * FROM variant_has_variantcaller;\""
+      test: "/usr/bin/mysql --user=root --password=$$MYSQL_ROOT_PASSWORD --database=variantstore_db --execute \"SELECT * FROM variant_has_variantcaller;\""
       interval: 5s
       timeout: 10s
       retries: 100
@@ -39,9 +37,4 @@ services:
         condition: service_healthy
     ports:
       - 8080:8080
-    environment:
-      DB_HOST: variantstore_db:3306
-      DB_NAME: variantstore_db
-      DB_USER: root
-      DB_PWD: ''
-      VARIANTSTORE_SECURITY_ENABLED: 'false'
+    env_file: docker-config.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,47 @@
+version: '1.0.1'
+
+# data volume for DB
+volumes:
+  dbstorage:
+
+# services (docker containers)
+services:
+  # MariaDB database
+  db:
+    image: mariadb:10.3
+    # Set max_allowed_packet to 256M
+    command: --max_allowed_packet=32505856
+    restart: always
+    container_name: variantstore_db
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+      MYSQL_DATABASE: variantstore_db
+    volumes:
+     - dbstorage:/data/db
+     - ./models/variantstore-model.sql:/docker-entrypoint-initdb.d/variantstore-init.sql:ro
+     - ./models/transaction-db.sql:/docker-entrypoint-initdb.d/transaction-init.sql:ro
+    ports:
+     - 3306:3306
+    healthcheck:
+      test: "/usr/bin/mysql --user=root --password='' --database=variantstore_db --execute \"SELECT * FROM variant_has_variantcaller;\""
+      interval: 5s
+      timeout: 10s
+      retries: 100
+  # Variantstore service
+  variantstore:
+    container_name: variantstore_app
+    build: .
+    image: variantstore:latest
+    links:
+      - db
+    depends_on:
+      db:
+        condition: service_healthy
+    ports:
+      - 8080:8080
+    environment:
+      DB_HOST: variantstore_db:3306
+      DB_NAME: variantstore_db
+      DB_USER: root
+      DB_PWD: ''
+      VARIANTSTORE_SECURITY_ENABLED: 'false'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '1.0.1'
+version: '2.2'
 
 # data volume for DB
 volumes:

--- a/docker-config.env
+++ b/docker-config.env
@@ -1,0 +1,23 @@
+#-----------------------------------------------------#
+#               Database Configurations               #
+#-----------------------------------------------------#
+MYSQL_DATABASE=variantstore_db
+MYSQL_ROOT_PASSWORD=my_secret_pw
+
+#-----------------------------------------------------#
+#             Variantstore Configurations             #
+#-----------------------------------------------------#
+# Database Access Point
+DB_HOST=variantstore_db:3306
+DB_NAME=variantstore_db
+DB_USER=root
+DB_PWD=my_secret_pw
+
+# Variantstore specific configs
+VARIANTSTORE_SECURITY_ENABLED='false'
+VARIANTSTORE_OAUTH2_ENABLED='false'
+VARIANTSTORE_OAUTH2_CLIENT_ID=''
+VARIANTSTORE_OAUTH2_CLIENT_SECRET=''
+VARIANTSTORE_OAUTH2_ISSUER=''
+VARIANTSTORE_OAUTH2_AUTH_URL=''
+VARIANTSTORE_OAUTH2_TOKEN_URL=''

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -25,3 +25,18 @@ Setup Database
 --------
 
 The complete installation of the Variantstore includes setting up the required databases to store the genomic information. Details can be found under :ref:`configuration`.
+
+One-Click Deployment
+--------
+
+The Variantstore also supports a one-click deployment via docker-compose.
+This allows fast setup of a functional variantstore & database infrastructure.
+
+.. code-block:: bash
+
+   cd variantstore-service/
+   docker-compose up
+
+
+However, it has to be noted that this kind of deployment is designed only for testing purposes.
+For a productive environment, a manual setup with individual configuration is recommended.


### PR DESCRIPTION
Heyho,

first, great work on this project!

I wanted to start the discussion about introducing deployment via docker-compose and especially compiling the variantstore in a docker container instead of compiling it locally and then uploading it into a container (as it is currently done by the Dockerfile).

Thus, I added a first draft for:
- One-click deployment via docker-compose
- A modified dockerfile for container-inside compiling
- Small extension to the documentation

The docker-compose script is based on the in-house docker-compose file, you sent me last year.

Your opinion on the following points would be quite interesting:
- Overall docker deployment option for fast deployment
- Docker deployment based on source build vs based on release jar import
- docker-compose.yml: VARIANTSTORE_SECURITY_ENABLED: 'false' -> This was for personal fast testing, but should be excluded (excluded = set to 'true' as default)
- A separate health check script which includes pinging both sql databases

Point to the associated issue (linked in the next comment) about docker deployment:  
Maybe, it is suitable to introduce docker as an alternative way for testing beside the manual & recommended way of variantstore setup.

Thanks in advance for your time.

Cheers,
Dominik