### PR TITLE
Adapt CI/CD for mariadb/postgresql interfaces

### DIFF
--- a/.github/workflows/ci_test_build_package.yml
+++ b/.github/workflows/ci_test_build_package.yml
@@ -27,6 +27,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      # build with maven and run tests
+      # build with maven and run tests with MariaDB
       - name: Build with Maven and run tests
-        run: mvn --batch-mode verify
+        run: mvn --batch-mode -Dmicronaut.environments=test-mariadb -Dtest='!life.qbic.db.postgres.**' verify
+
+      # build with maven and run tests with Postgresql
+      - name: Build with Maven and run tests
+        run: mvn --batch-mode -Dmicronaut.environments=test-postgres -Dtest='!life.qbic.db.mariadb.**' verify


### PR DESCRIPTION
Add separate tests for mariadb and PostgreSQL. These tests will use different configurations and run shared and db-specific tests.