### PR TITLE
Add ensembl import for postgres

### DIFF
--- a/models/V1__variantstore-model-postgres.sql
+++ b/models/V1__variantstore-model-postgres.sql
@@ -108,7 +108,7 @@ CREATE TABLE gene (
     chr character varying,
     start bigint,
     "end" bigint,
-    synonyms character varying,
+    synonyms character varying[],
     geneid character varying,
     description character varying,
     strand character varying,

--- a/src/main/groovy/life/qbic/variantstore/controller/GeneController.groovy
+++ b/src/main/groovy/life/qbic/variantstore/controller/GeneController.groovy
@@ -112,6 +112,7 @@ class GeneController {
      * @param args the filter arguments
      * @return 200 OK or 400 Bad Request
      */
+    @TransactionalAdvice('${database.specifier}')
     @Operation(summary = "Upload gene information",
             description = "Upload Ensembl GFF3 file to add gene information to the store.",
             tags = "Gene")
@@ -122,10 +123,8 @@ class GeneController {
             File tempFile = File.createTempFile(files.getFilename(), "temp");
             Path path = Paths.get(tempFile.getAbsolutePath());
             Files.write(path, files.getBytes());
-            //TODO ensembl POJO
             EnsemblParser ensembl = new EnsemblParser(tempFile)
-            service.storeGeneInformationInStore(ensembl)
-
+            service.storeGeneInformationInStore(ensembl.ensemblContext)
             return HttpResponse.ok("Upload of gene information successful.")
         } catch (IOException exception) {
             log.error(exception)

--- a/src/main/groovy/life/qbic/variantstore/model/Ensembl.groovy
+++ b/src/main/groovy/life/qbic/variantstore/model/Ensembl.groovy
@@ -1,5 +1,6 @@
 package life.qbic.variantstore.model
 
+import groovy.transform.EqualsAndHashCode
 import io.micronaut.data.annotation.GeneratedValue
 import io.micronaut.data.annotation.Id
 import io.micronaut.data.annotation.MappedEntity
@@ -14,6 +15,7 @@ import io.micronaut.data.jdbc.annotation.JoinTable
  * @since: 1.1.0
  */
 @MappedEntity
+@EqualsAndHashCode
 class Ensembl {
 
     /**
@@ -21,11 +23,11 @@ class Ensembl {
      */
     @GeneratedValue
     @Id
-    private Long id
+    Long id
 
-    private final Integer version
+    Integer version
 
-    private final String date
+    String date
 
     /**
      * The reference genome associated with a Ensembl DB instance
@@ -38,8 +40,10 @@ class Ensembl {
             joinColumns = @JoinColumn(name = "ensembl_id"),
             inverseJoinColumns = @JoinColumn(name = "gene_id")
     )
-    @Relation(value = Relation.Kind.MANY_TO_MANY, cascade = Relation.Cascade.PERSIST)
-    private Set<Gene> genes = new HashSet<>()
+    @Relation(value = Relation.Kind.MANY_TO_MANY, cascade = [Relation.Cascade.PERSIST, Relation.Cascade.UPDATE])
+    Set<Gene> genes
+
+    Ensembl() { }
 
     Ensembl(Integer version, String date) {
         this.version = version

--- a/src/main/groovy/life/qbic/variantstore/model/Gene.groovy
+++ b/src/main/groovy/life/qbic/variantstore/model/Gene.groovy
@@ -21,7 +21,7 @@ import io.swagger.v3.oas.annotations.media.Schema
  * @since: 1.1.0
  */
 @MappedEntity(namingStrategy = NamingStrategies.LowerCase.class)
-@EqualsAndHashCode
+@EqualsAndHashCode(includeFields=true, excludes = "id, consequences, ensembles")
 @Schema(name = "Gene", description = "A Gene")
 @Builder
 class Gene {

--- a/src/main/groovy/life/qbic/variantstore/model/ReferenceGenome.groovy
+++ b/src/main/groovy/life/qbic/variantstore/model/ReferenceGenome.groovy
@@ -28,7 +28,7 @@ class ReferenceGenome {
 
     @GeneratedValue
     @Id
-    private Long id
+    Long id
 
     String source
     String build
@@ -38,7 +38,7 @@ class ReferenceGenome {
     Set<Variant> variants
 
     @Relation(value = Relation.Kind.ONE_TO_MANY, mappedBy = "referencegenome")
-    private Set<Ensembl> ensemblInstances
+    Set<Ensembl> ensemblInstances
 
     ReferenceGenome(String source, String build, String version) {
         this.source = source

--- a/src/main/groovy/life/qbic/variantstore/parser/MetadataReader.groovy
+++ b/src/main/groovy/life/qbic/variantstore/parser/MetadataReader.groovy
@@ -30,12 +30,6 @@ class MetadataReader {
         Case entity = parseCase(jsonContent)
         List<Sample> samples = parseSample(jsonContent)
         Project project = parseProject(jsonContent)
-
-        //project.setCases(bla)
-        //entity.setProject(project)
-        //project.getC
-        //samples.each {sample -> sample.setEntity(entity) }
-
         this.metadataContext = new MetadataContext(parseIsSomatic(jsonContent), parseCallingSoftware(jsonContent), parseAnnotationSoftware(jsonContent), parseReferenceGenome(jsonContent), entity, samples, project)
     }
 

--- a/src/main/groovy/life/qbic/variantstore/repositories/EnsemblRepository.groovy
+++ b/src/main/groovy/life/qbic/variantstore/repositories/EnsemblRepository.groovy
@@ -1,11 +1,15 @@
 package life.qbic.variantstore.repositories
 
+import io.micronaut.data.annotation.Join
+import io.micronaut.data.annotation.NamingStrategy
 import io.micronaut.data.annotation.Query
 import io.micronaut.data.annotation.Repository
 import io.micronaut.data.jdbc.annotation.JdbcRepository
+import io.micronaut.data.model.naming.NamingStrategies
 import io.micronaut.data.model.query.builder.sql.Dialect
 import io.micronaut.data.repository.CrudRepository
 import life.qbic.variantstore.model.Ensembl
+import life.qbic.variantstore.model.ReferenceGenome
 
 
 /**
@@ -15,10 +19,14 @@ import life.qbic.variantstore.model.Ensembl
  */
 @Repository("variantstore-postgres")
 @JdbcRepository(dialect = Dialect.POSTGRES)
+@NamingStrategy(NamingStrategies.LowerCase.class)
 interface EnsemblRepository extends CrudRepository<Ensembl, Long> {
 
     @Override
     Optional<Ensembl> findById(Long id)
+
+    @Join(value = "genes", type = Join.Type.LEFT_FETCH, alias = "genes")
+    Optional<Ensembl> find(Integer version, String date, ReferenceGenome referenceGenome)
 
     @Query("SELECT MAX(version) FROM ensembl")
     Integer fetchMaxVersion()

--- a/src/main/groovy/life/qbic/variantstore/repositories/GeneRepository.groovy
+++ b/src/main/groovy/life/qbic/variantstore/repositories/GeneRepository.groovy
@@ -54,8 +54,8 @@ abstract class GeneRepository implements CrudRepository<Gene, Long>{
         }
     }
 
-    @Join(value = "ensembles", type = Join.Type.INNER, alias = "ensembl")
-    @Where("ensembl.version = :ensemblVersion")
+    //@Join(value = "ensembles", type = Join.Type.INNER, alias = "ensembl")
+    //@Where("ensembl.version = :ensemblVersion")
     abstract Set<Gene> searchByGeneId(String geneId, int ensemblVersion)
 
 

--- a/src/main/groovy/life/qbic/variantstore/service/VariantstoreInformationCenter.groovy
+++ b/src/main/groovy/life/qbic/variantstore/service/VariantstoreInformationCenter.groovy
@@ -2,7 +2,6 @@ package life.qbic.variantstore.service
 
 import groovy.util.logging.Log4j2
 import life.qbic.variantstore.model.*
-import life.qbic.variantstore.parser.EnsemblParser
 import life.qbic.variantstore.parser.MetadataContext
 import life.qbic.variantstore.parser.MetadataReader
 import life.qbic.variantstore.parser.SimpleVCFReader
@@ -217,9 +216,9 @@ class VariantstoreInformationCenter implements VariantstoreService{
      * {@inheritDoc}
      */
     @Override
-    void storeGeneInformationInStore(EnsemblParser ensembl) {
+    void storeGeneInformationInStore(Ensembl ensembl) {
         log.info("Storing provided gene information in store")
-        storage.storeGenesWithMetadata(ensembl.version, ensembl.date, ensembl.referenceGenome, ensembl.genes)
+        storage.storeGenesWithMetadata(ensembl)
         log.info("...done.")
     }
 

--- a/src/main/groovy/life/qbic/variantstore/service/VariantstoreService.groovy
+++ b/src/main/groovy/life/qbic/variantstore/service/VariantstoreService.groovy
@@ -1,7 +1,6 @@
 package life.qbic.variantstore.service
 
 import life.qbic.variantstore.model.*
-import life.qbic.variantstore.parser.EnsemblParser
 import life.qbic.variantstore.repositories.TransactionStatusRepository
 import life.qbic.variantstore.util.ListingArguments
 import jakarta.inject.Singleton
@@ -112,7 +111,7 @@ interface VariantstoreService {
     void storeVariantsInStore(String metadata, InputStream inputStream, TransactionStatusRepository repository, TransactionStatus transactionStatus)
     /**
      * Stores gene information provided in a GFF3 file (Ensembl) in the store.
-     * @param ensemblParser parser to extract information from GFF3 file
+     * @param ensemblContext the ensembl context holding information parsed from Ensembl
      */
-    void storeGeneInformationInStore(EnsemblParser ensemblParser)
+    void storeGeneInformationInStore(Ensembl ensemblContext)
 }

--- a/src/main/groovy/life/qbic/variantstore/service/VariantstoreStorage.groovy
+++ b/src/main/groovy/life/qbic/variantstore/service/VariantstoreStorage.groovy
@@ -3,6 +3,7 @@ package life.qbic.variantstore.service
 import life.qbic.variantstore.database.VariantstoreStorageException
 import life.qbic.variantstore.model.Case
 import life.qbic.variantstore.model.Consequence
+import life.qbic.variantstore.model.Ensembl
 import life.qbic.variantstore.model.Gene
 import life.qbic.variantstore.model.ReferenceGenome
 import life.qbic.variantstore.model.Sample
@@ -10,6 +11,7 @@ import life.qbic.variantstore.model.SimpleVariantContext
 import life.qbic.variantstore.model.Variant
 import life.qbic.variantstore.model.VariantCaller
 import life.qbic.variantstore.model.Annotation
+
 import life.qbic.variantstore.parser.MetadataContext
 import life.qbic.variantstore.util.ListingArguments
 import jakarta.inject.Singleton
@@ -152,10 +154,7 @@ interface VariantstoreStorage {
 
     /**
      * Store genes with provided metadata in the store.
-     * @param version the version of the provided information
-     * @param date the date of the provided information
-     * @param referenceGenome the reference genome
-     * @param genes the provided genes
+     * @param ensemblContext the ensemblContext
      */
-    void storeGenesWithMetadata(Integer version, String date, ReferenceGenome referenceGenome, List<Gene> genes) throws VariantstoreStorageException
+    void storeGenesWithMetadata(Ensembl ensemblContext) throws VariantstoreStorageException
 }

--- a/src/main/resources/db/postgresql/V1__variantstore-model-postgres.sql
+++ b/src/main/resources/db/postgresql/V1__variantstore-model-postgres.sql
@@ -108,7 +108,7 @@ CREATE TABLE gene (
     chr character varying,
     start bigint,
     "end" bigint,
-    synonyms character varying,
+    synonyms character varying[],
     geneid character varying,
     description character varying,
     strand character varying,

--- a/src/test/groovy/life/qbic/processing/VariantImportSpec.groovy
+++ b/src/test/groovy/life/qbic/processing/VariantImportSpec.groovy
@@ -61,7 +61,7 @@ class VariantImportSpec extends Specification {
                 .accept(MediaType.APPLICATION_JSON)
                 .contentType(MediaType.MULTIPART_FORM_DATA)
         HttpResponse response = httpClient.toBlocking().exchange(request)
-        PollingConditions uploaded = new PollingConditions(delay: 1, initialDelay: 0.5, timeout: 30)
+        PollingConditions uploaded = new PollingConditions(delay: 2, initialDelay: 1, timeout: 60)
 
         then:
         response.status() == status

--- a/src/test/resources/data/Homo_sapiens.GRCh38.87.chromosome.15.gff3
+++ b/src/test/resources/data/Homo_sapiens.GRCh38.87.chromosome.15.gff3
@@ -1,0 +1,88 @@
+##gff-version   3
+##sequence-region   15 1 101991189
+#!genome-build  GRCh38.p7
+#!genome-version GRCh38
+#!genome-date 2013-12
+#!genome-build-accession NCBI:GCA_000001405.22
+#!genebuild-last-updated 2016-06
+15	GRCh38	chromosome	1	101991189	.	.	.	ID=chromosome:15;Alias=CM000677.2,chr15,NC_000015.10
+###
+15	havana	gene	19878555	19887814	.	+	.	ID=gene:ENSG00000215567;Name=RP11-79C23.1;biotype=unprocessed_pseudogene;gene_id=ENSG00000215567;havana_gene=OTTHUMG00000163698;havana_version=1;logic_name=havana;version=5
+15	havana	pseudogene	19878555	19887814	.	+	.	ID=transcript:ENST00000524329;Parent=gene:ENSG00000215567;Name=RP11-79C23.1-001;biotype=unprocessed_pseudogene;havana_transcript=OTTHUMT00000374791;havana_version=1;tag=basic;transcript_id=ENST00000524329;transcript_support_level=NA;version=1
+15	havana	exon	19878555	19878668	.	+	.	Parent=transcript:ENST00000524329;Name=ENSE00002133693;constitutive=1;ensembl_end_phase=-1;ensembl_phase=-1;exon_id=ENSE00002133693;rank=1;version=1
+15	havana	exon	19878831	19879004	.	+	.	Parent=transcript:ENST00000524329;Name=ENSE00003544224;constitutive=1;ensembl_end_phase=-1;ensembl_phase=-1;exon_id=ENSE00003544224;rank=2;version=1
+15	havana	exon	19881201	19881307	.	+	.	Parent=transcript:ENST00000524329;Name=ENSE00003523105;constitutive=1;ensembl_end_phase=-1;ensembl_phase=-1;exon_id=ENSE00003523105;rank=3;version=1
+15	havana	exon	19882277	19882439	.	+	.	Parent=transcript:ENST00000524329;Name=ENSE00002122474;constitutive=1;ensembl_end_phase=-1;ensembl_phase=-1;exon_id=ENSE00002122474;rank=4;version=1
+15	havana	exon	19884979	19885043	.	+	.	Parent=transcript:ENST00000524329;Name=ENSE00003610421;constitutive=1;ensembl_end_phase=-1;ensembl_phase=-1;exon_id=ENSE00003610421;rank=5;version=1
+15	havana	exon	19887724	19887814	.	+	.	Parent=transcript:ENST00000524329;Name=ENSE00002098314;constitutive=1;ensembl_end_phase=-1;ensembl_phase=-1;exon_id=ENSE00002098314;rank=6;version=1
+###
+15	ensembl	snRNA_gene	19883614	19883716	.	+	.	ID=gene:ENSG00000201241;Name=RNU6-978P;biotype=snRNA;description=RNA%2C U6 small nuclear 978%2C pseudogene [Source:HGNC Symbol%3BAcc:HGNC:47941];gene_id=ENSG00000201241;logic_name=ncrna;version=1
+15	ensembl	snRNA	19883614	19883716	.	+	.	ID=transcript:ENST00000364371;Parent=gene:ENSG00000201241;Name=RNU6-978P-201;biotype=snRNA;tag=basic;transcript_id=ENST00000364371;transcript_support_level=NA;version=1
+15	ensembl	exon	19883614	19883716	.	+	.	Parent=transcript:ENST00000364371;Name=ENSE00001439134;constitutive=1;ensembl_end_phase=-1;ensembl_phase=-1;exon_id=ENSE00001439134;rank=1;version=1
+###
+15	.	biological_region	19898785	19898891	1	-	.	external_name=rank %3D 1;logic_name=firstef
+15	.	biological_region	19898888	19899448	430	.	.	external_name=oe %3D 0.62;logic_name=cpg
+15	.	biological_region	19898950	19898952	0.999	-	.	logic_name=eponine
+15	.	biological_region	19898981	19898987	0.999	-	.	logic_name=eponine
+15	.	biological_region	19899029	19899031	0.999	-	.	logic_name=eponine
+15	.	biological_region	19899046	19899047	0.999	-	.	logic_name=eponine
+15	.	biological_region	19899111	19899113	0.999	-	.	logic_name=eponine
+15	.	biological_region	19899131	19899137	0.999	-	.	logic_name=eponine
+15	havana	gene	19899334	19899559	.	+	.	ID=gene:ENSG00000258463;Name=RP11-173D3.3;biotype=processed_pseudogene;gene_id=ENSG00000258463;havana_gene=OTTHUMG00000171715;havana_version=1;logic_name=havana;version=1
+15	havana	processed_pseudogene	19899334	19899559	.	+	.	ID=transcript:ENST00000553634;Parent=gene:ENSG00000258463;Name=RP11-173D3.3-001;biotype=processed_pseudogene;havana_transcript=OTTHUMT00000414850;havana_version=1;tag=basic;transcript_id=ENST00000553634;transcript_support_level=NA;version=1
+15	havana	exon	19899334	19899559	.	+	.	Parent=transcript:ENST00000553634;Name=ENSE00002481859;constitutive=1;ensembl_end_phase=-1;ensembl_phase=-1;exon_id=ENSE00002481859;rank=1;version=1
+###
+15	.	biological_region	19899358	19899555	1	+	.	external_name=rank %3D 1;logic_name=firstef
+15	.	biological_region	19943441	19944862	1.82e+03	.	.	external_name=oe %3D 0.78;logic_name=cpg
+15	.	biological_region	19943488	19943489	0.999	-	.	logic_name=eponine
+15	.	biological_region	19943524	19943531	0.999	-	.	logic_name=eponine
+15	.	biological_region	19943555	19943556	0.999	-	.	logic_name=eponine
+15	.	biological_region	19943591	19943595	0.999	-	.	logic_name=eponine
+15	.	biological_region	19943609	19944614	1	-	.	external_name=rank %3D 1;logic_name=firstef
+15	.	biological_region	19943613	19943619	0.999	-	.	logic_name=eponine
+15	.	biological_region	19943639	19943641	0.999	-	.	logic_name=eponine
+15	.	biological_region	19943649	19944614	1	-	.	external_name=rank %3D 2;logic_name=firstef
+15	.	biological_region	19943662	19943666	0.999	-	.	logic_name=eponine
+15	.	biological_region	19943666	19943729	0.999	+	.	external_name=rank %3D 1;logic_name=firstef
+15	.	biological_region	19943727	19943733	0.999	-	.	logic_name=eponine
+15	.	biological_region	19943768	19943770	0.999	-	.	logic_name=eponine
+15	.	biological_region	19943785	19943788	0.999	-	.	logic_name=eponine
+15	.	biological_region	19943800	19943804	0.999	-	.	logic_name=eponine
+15	.	biological_region	19943821	19943829	0.999	-	.	logic_name=eponine
+15	.	biological_region	19943839	19943843	0.999	-	.	logic_name=eponine
+15	.	biological_region	19943858	19943866	0.999	-	.	logic_name=eponine
+15	.	biological_region	19943893	19943902	0.999	-	.	logic_name=eponine
+15	.	biological_region	19943917	19943923	0.999	-	.	logic_name=eponine
+15	.	biological_region	19943958	19943964	0.999	-	.	logic_name=eponine
+15	.	biological_region	19943998	19944004	0.999	-	.	logic_name=eponine
+15	.	biological_region	19944020	19944027	0.999	-	.	logic_name=eponine
+15	.	biological_region	19944044	19944051	0.999	-	.	logic_name=eponine
+15	.	biological_region	19944058	19944058	0.999	+	.	logic_name=eponine
+15	.	biological_region	19944070	19944078	0.999	-	.	logic_name=eponine
+15	.	biological_region	19944093	19944101	0.999	-	.	logic_name=eponine
+15	.	biological_region	19944111	19944119	0.999	-	.	logic_name=eponine
+15	.	biological_region	19944147	19944154	0.999	-	.	logic_name=eponine
+15	.	biological_region	19944164	19944171	0.999	-	.	logic_name=eponine
+15	.	biological_region	19944180	19944186	0.999	-	.	logic_name=eponine
+15	.	biological_region	19944213	19944214	0.999	-	.	logic_name=eponine
+15	.	biological_region	19944229	19944233	0.999	-	.	logic_name=eponine
+15	.	biological_region	19944252	19944259	0.999	-	.	logic_name=eponine
+15	.	biological_region	19944277	19944280	0.999	-	.	logic_name=eponine
+15	.	biological_region	19944288	19944614	1	-	.	external_name=rank %3D 3;logic_name=firstef
+15	.	biological_region	19944293	19944297	0.999	-	.	logic_name=eponine
+15	.	biological_region	19944316	19944319	0.999	-	.	logic_name=eponine
+15	.	biological_region	19944333	19944337	0.999	-	.	logic_name=eponine
+15	.	biological_region	19944357	19944361	0.999	-	.	logic_name=eponine
+15	.	biological_region	19944399	19944404	0.999	-	.	logic_name=eponine
+15	.	biological_region	19944421	19944427	0.999	-	.	logic_name=eponine
+15	.	biological_region	19944438	19944444	0.999	-	.	logic_name=eponine
+15	.	biological_region	19944480	19944485	0.999	-	.	logic_name=eponine
+15	.	biological_region	19944523	19944525	0.999	-	.	logic_name=eponine
+15	.	biological_region	19944547	19944550	0.999	-	.	logic_name=eponine
+15	.	biological_region	19944567	19944571	0.999	-	.	logic_name=eponine
+15	.	biological_region	19944605	19944608	0.999	-	.	logic_name=eponine
+15	.	biological_region	19944629	19944632	0.999	-	.	logic_name=eponine
+15	.	biological_region	19944681	19944686	0.999	-	.	logic_name=eponine
+15	.	biological_region	19944729	19944732	0.999	-	.	logic_name=eponine
+15	.	biological_region	19944751	19944755	0.999	-	.	logic_name=eponine
+15	.	biological_region	19944806	19944809	0.999	-	.	logic_name=eponine

--- a/src/test/resources/db-test/postgresql/V1__variantstore-postgres_test_db.sql
+++ b/src/test/resources/db-test/postgresql/V1__variantstore-postgres_test_db.sql
@@ -363,7 +363,7 @@ CREATE TABLE gene (
     chr character varying,
     start bigint,
     "end" bigint,
-    synonyms character varying,
+    synonyms character varying[],
     geneid character varying,
     description character varying,
     strand character varying,


### PR DESCRIPTION
This 
- adds the Ensembl import functionality for a PostgreSQL datasource
- makes use of the `Ensembl` class instead of storing information in the parser
- adds a test for the gene import
- adds gff3 test data
- fixes an issue with one property in the `gene` table 