### PR TITLE
Fix OAuth configuration

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -15,7 +15,9 @@ server:
 
 Security (authentication and authorization) is enabled by default but you can deactivate it by setting the environment variable `VARIANTSTORE_SECURITY_ENABLED` to `false`. If security is enabled all protected endpoints (i.e. all endpoints except the `/beacon` endpoint) can only be accessed by authenticated users.
 
-In addition to that, the Variantstore supports authentication with OAuth 2.0 servers. This includes support for the OpenID standard. At the moment we only tested/support the option to use Keycloak as provider.
+In addition to that, the Variantstore supports authentication with OAuth 2.0 servers. This includes support for the OpenID standard. Authentication using Keycloak as provider has been tested. However, other provider that support OpenID such as [Okta](https://developer.okta.com/), [AWS Cognito](https://aws.amazon.com/cognito), and [Google](https://developers.google.com/identity/protocols/OpenIDConnect) should work as well when configured properly.
+
+Authentication mode is set to `idtoken` by default. The mode can be changed by setting the environment variable `VARIANTSTORE_AUTHENTICATION_MODE`. Please refer to the official Micronaut [docs](https://micronaut-projects.github.io/micronaut-security/latest/guide/#authenticationStrategy) for valid values.
 
 In order to enable authentication with OAuth 2.0 servers, set `VARIANTSTORE_OAUTH2_ENABLED` to `true` and provide all necessary details using the following environment variables:
 

--- a/src/main/groovy/life/qbic/variantstore/controller/CaseController.groovy
+++ b/src/main/groovy/life/qbic/variantstore/controller/CaseController.groovy
@@ -94,7 +94,7 @@ class CaseController {
         log.info("Resource request for cases with filtering options.")
         try {
             List<Case> cases = service.getCasesForSpecifiedProperties(args)
-            return cases ? HttpResponse.ok(cases) : HttpResponse.ok([])
+            return cases ? HttpResponse.ok(cases) : HttpResponse.notFound("No cases found matching provided attributes.")
         } catch (Exception e) {
             log.error(e)
             return HttpResponse.serverError("Unexpected error, resource could not be accessed.")

--- a/src/main/groovy/life/qbic/variantstore/controller/GeneController.groovy
+++ b/src/main/groovy/life/qbic/variantstore/controller/GeneController.groovy
@@ -97,7 +97,6 @@ class GeneController {
         log.info("Resource request for genes with filtering options.")
         try {
             Set<Gene> genes = service.getGenesForSpecifiedProperties(args)
-            log.info(genes)
             return genes ? HttpResponse.ok(genes) : HttpResponse.notFound("No genes found matching provided attributes.")
         }
         catch (Exception e) {

--- a/src/main/groovy/life/qbic/variantstore/controller/GeneController.groovy
+++ b/src/main/groovy/life/qbic/variantstore/controller/GeneController.groovy
@@ -97,11 +97,10 @@ class GeneController {
         log.info("Resource request for genes with filtering options.")
         try {
             Set<Gene> genes = service.getGenesForSpecifiedProperties(args)
-            return genes ? HttpResponse.ok(genes) : HttpResponse.notFound("No genes found matching provided " +
-                    "attributes.").body("")
+            log.info(genes)
+            return genes ? HttpResponse.ok(genes) : HttpResponse.notFound("No genes found matching provided attributes.")
         }
         catch (Exception e) {
-            log.error(e)
             return HttpResponse.serverError("Unexpected error, resource could not be accessed.")
         }
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,6 +29,7 @@ micronaut:
         mapping: /css/**
   security:
     enabled: ${variantstore-security-enabled:true}
+    authentication: ${variantstore-authentication-mode:idtoken}
     intercept-url-map:
       - pattern: /swagger/**
         http-method: GET
@@ -79,12 +80,12 @@ micronaut:
             auth-method: client-secret-jwt
 datasources:
   variantstore_postgres:
-    url: jdbc:postgresql://${db-host:""}/${db-name:""}
+    url: jdbc:postgresql://${db-host:""}/${db-name:""}?currentSchema=variantstore
     username: ${db-user:""}
     password: ${db-pwd:""}
     driverClassName: org.postgresql.Driver
   transactions:
-    url: jdbc:postgresql://${db-transaction-host:""}/${db-transaction-name:""}
+    url: jdbc:postgresql://${db-transaction-host:""}/${db-transaction-name:""}?currentSchema=transactions
     username: ${db-transaction-user:""}
     password: ${db-transaction-pwd:""}
     driverClassName: org.postgresql.Driver

--- a/src/test/groovy/life/qbic/controller/CaseControllerSpec.groovy
+++ b/src/test/groovy/life/qbic/controller/CaseControllerSpec.groovy
@@ -81,9 +81,18 @@ class CaseControllerSpec extends Specification{
 
         where:
         chr | size
-        1   |   0
         4   |   2
         15  |   1
         "X" |   2
+    }
+
+    @Unroll
+    void "should return NOT_FOUND when no case available after filtering for chromosome"() {
+        when:
+        HttpResponse response = httpClient.toBlocking().exchange("/cases?chromosome=1", List)
+
+        then:
+        HttpClientResponseException t = thrown(HttpClientResponseException)
+        t.getStatus().code == 404
     }
 }


### PR DESCRIPTION
This
 * fixes the OAuth 2.0 configuration, which was necessary due to the changes in the new Micronaut/Security versions
 * adds documentation on the OAuth 2.0 configuration
 * adds the schema names to the PostgreSQL datasource configuration 