### PR TITLE
add project controller and respective functionality

### DIFF
--- a/src/main/groovy/life/qbic/variantstore/controller/ProjectController.groovy
+++ b/src/main/groovy/life/qbic/variantstore/controller/ProjectController.groovy
@@ -1,0 +1,107 @@
+package life.qbic.variantstore.controller
+
+import groovy.util.logging.Log4j2
+import io.micronaut.core.annotation.NonNull
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.PathVariable
+import io.micronaut.http.annotation.QueryValue
+import io.micronaut.security.annotation.Secured
+import io.micronaut.security.rules.SecurityRule
+import io.micronaut.transaction.annotation.TransactionalAdvice
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import jakarta.inject.Inject
+import life.qbic.variantstore.model.BeaconAlleleResponse
+import life.qbic.variantstore.model.Project
+import life.qbic.variantstore.model.Sample
+import life.qbic.variantstore.model.Variant
+import life.qbic.variantstore.service.VariantstoreService
+import life.qbic.variantstore.util.ListingArguments
+
+import javax.validation.constraints.Pattern
+import javax.validation.constraints.PositiveOrZero
+
+/**
+ * Controller for Beacon requests
+ *
+ * Answers the question: "Have you observed this genotype?"
+ * A GA4GH Beacon based on the v0.4 specification. Given a position in a chromosome and an allele, the beacon looks
+ * for matching mutations at that location and returns a response accordingly.
+ *
+ * @since: 1.0.0
+ */
+@Log4j2
+@Controller("/projects")
+@Secured(SecurityRule.IS_ANONYMOUS)
+class ProjectController {
+
+    /**
+     * The variantstore service
+     */
+    private final VariantstoreService service
+
+    @Inject
+    ProjectController(VariantstoreService service) {
+        this.service = service
+    }
+
+    /**
+     * Retrieve project by identifier
+     * @param identifier the project identifier
+     * @return the found variant or 404 Not Found
+     */
+    @TransactionalAdvice('${database.specifier}')
+    @Get(uri = "/{id}", produces = MediaType.APPLICATION_JSON)
+    @Operation(summary = "Request a project",
+            description = "The project with the specified identifier is returned.",
+            tags = "Project")
+    @ApiResponse(responseCode = "200", description = "Returns a project", content = @Content(mediaType = "application/json",
+            schema = @Schema(implementation = Project.class)))
+    @ApiResponse(responseCode = "400", description = "Invalid project identifier supplied")
+    @ApiResponse(responseCode = "404", description = "Project not found")
+    HttpResponse getProject(@PathVariable(name = "id") String identifier) {
+        log.info("Resource request for project: $identifier")
+        try {
+            Optional<Project> project = service.getProjectForProjectId(identifier)
+            return project.present ? HttpResponse.ok(project.get()) : HttpResponse.notFound("No Project found for given "
+                    + "identifier.").body("")
+        } catch (IllegalArgumentException e) {
+            log.error(e)
+            return HttpResponse.badRequest("Invalid project identifier supplied.")
+        } catch (Exception e) {
+            log.error(e)
+            return HttpResponse.serverError("Unexpected error, resource could not be accessed.")
+        }
+    }
+
+    /**
+     * Retrieve projects based on filtering criteria
+     * @param args the filter arguments
+     * @return the found projects or 404 Not Found
+     */
+    @TransactionalAdvice('${database.specifier}')
+    @Get(uri = "{?args*}", produces = MediaType.APPLICATION_JSON)
+    @Operation(summary = "Request a set of projects",
+            description = "The samples matching the supplied properties are returned.",
+            tags = "Project")
+    @ApiResponse(responseCode = "200", description = "Returns a set of projects", content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = Project.class)))
+    @ApiResponse(responseCode = "404", description = "No samples found matching provided attributes")
+    HttpResponse getProjects(ListingArguments args){
+        log.info("Resource request for projects with filtering options.")
+        try {
+            List<Project> projects = service.getProjectsForSpecifiedProperties(args)
+            return projects ? HttpResponse.ok(projects) : HttpResponse.notFound("No projects found matching provided attributes.")
+        }
+        catch (Exception e) {
+            log.error(e)
+            return HttpResponse.serverError("Unexpected error, resource could not be accessed.")
+        }
+    }
+}

--- a/src/main/groovy/life/qbic/variantstore/database/PostgresSqlVariantstoreStorage.groovy
+++ b/src/main/groovy/life/qbic/variantstore/database/PostgresSqlVariantstoreStorage.groovy
@@ -71,6 +71,14 @@ class PostgresSqlVariantstoreStorage implements VariantstoreStorage {
      * {@inheritDoc}
      */
     @Override
+    Optional<Project> findProjectById(String identifier) {
+        return projectRepository.findByIdentifier(identifier)
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     List<Case> findCaseById(String identifier) {
         return caseRepository.findByIdentifier(identifier)
     }
@@ -108,6 +116,18 @@ class PostgresSqlVariantstoreStorage implements VariantstoreStorage {
             return geneRepository.searchByGeneId(identifier)
         } catch (Exception e) {
             throw new VariantstoreStorageException("Could not fetch gene with identifier $identifier.", e.printStackTrace())
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    List<Project> findProjects(ListingArguments args) {
+        try {
+            return projectRepository.findAll()
+        } catch (Exception e) {
+            throw new VariantstoreStorageException("Could not fetch projects.", e.fillInStackTrace())
         }
     }
 

--- a/src/main/groovy/life/qbic/variantstore/service/VariantstoreInformationCenter.groovy
+++ b/src/main/groovy/life/qbic/variantstore/service/VariantstoreInformationCenter.groovy
@@ -48,6 +48,14 @@ class VariantstoreInformationCenter implements VariantstoreService{
      * {@inheritDoc}
      */
     @Override
+    Optional<Project> getProjectForProjectId(String projectId) {
+        return storage.findProjectById(projectId)
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     List<Case> getCaseForCaseId(String caseId) {
         return storage.findCaseById(caseId)
     }
@@ -87,6 +95,14 @@ class VariantstoreInformationCenter implements VariantstoreService{
     @Override
     List<Sample> getSampleForSampleId(String sampleId) {
         return storage.findSampleById(sampleId)
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    List<Project> getProjectsForSpecifiedProperties(@NonNull ListingArguments args) {
+        return storage.findProjects(args)
     }
 
     /**

--- a/src/main/groovy/life/qbic/variantstore/service/VariantstoreService.groovy
+++ b/src/main/groovy/life/qbic/variantstore/service/VariantstoreService.groovy
@@ -1,5 +1,6 @@
 package life.qbic.variantstore.service
 
+import io.micronaut.core.annotation.NonNull
 import life.qbic.variantstore.model.*
 import life.qbic.variantstore.repositories.TransactionStatusRepository
 import life.qbic.variantstore.util.ListingArguments
@@ -12,6 +13,13 @@ import jakarta.inject.Singleton
  */
 @Singleton
 interface VariantstoreService {
+
+    /**
+     * Retrieve project for specified project identifier.
+     * @param identifier the project identifier
+     * @return list of found project
+     */
+    Optional<Project> getProjectForProjectId(String identifier)
 
     /**
      * Retrieves cases for specified case identifier.
@@ -43,10 +51,17 @@ interface VariantstoreService {
     List<Sample> getSampleForSampleId(String identifier)
 
     /**
-     * Retrieves cases for specified filtering options.
+     * Retrieves projects for specified filtering options.
      * @param args the provided filtering options
-     * @return list of cases genes
+     * @return list of found projects
      */
+    List<Project> getProjectsForSpecifiedProperties(ListingArguments args)
+
+    /**
+    * Retrieves cases for specified filtering options.
+    * @param args the provided filtering options
+    * @return list of found cases
+    */
     List<Case> getCasesForSpecifiedProperties(ListingArguments args)
 
     /**

--- a/src/main/groovy/life/qbic/variantstore/service/VariantstoreStorage.groovy
+++ b/src/main/groovy/life/qbic/variantstore/service/VariantstoreStorage.groovy
@@ -5,6 +5,7 @@ import life.qbic.variantstore.model.Case
 import life.qbic.variantstore.model.Consequence
 import life.qbic.variantstore.model.Ensembl
 import life.qbic.variantstore.model.Gene
+import life.qbic.variantstore.model.Project
 import life.qbic.variantstore.model.ReferenceGenome
 import life.qbic.variantstore.model.Sample
 import life.qbic.variantstore.model.SimpleVariantContext
@@ -38,6 +39,13 @@ interface VariantstoreStorage {
                                           String reference, String observed, String assemblyId)
 
     /**
+     * Find project in store by identifier.
+     * @param identifier the project identifier
+     * @return optional project
+     */
+    Optional<Project> findProjectById(String identifier)
+
+    /**
      * Find case in store by identifier.
      * @param identifier the case identifier
      * @return list of found cases
@@ -65,6 +73,13 @@ interface VariantstoreStorage {
      * @return set of found genes
      */
     Set<Gene> findGeneById(String identifier, @NonNull ListingArguments args)
+
+    /**
+     * Find projects for specified filtering options.
+     * @param args the provided filtering options
+     * @return list of found projects
+     */
+    List<Project> findProjects(@NonNull ListingArguments args)
 
     /**
      * Find cases for specified filtering options.

--- a/src/test/groovy/life/qbic/controller/ProjectControllerSpec.groovy
+++ b/src/test/groovy/life/qbic/controller/ProjectControllerSpec.groovy
@@ -1,0 +1,70 @@
+package life.qbic.controller
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.http.client.exceptions.HttpClientResponseException
+import io.micronaut.runtime.server.EmbeddedServer
+import io.micronaut.rxjava3.http.client.Rx3HttpClient
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import life.qbic.variantstore.controller.ProjectController
+import spock.lang.Specification
+import spock.lang.Unroll
+
+@MicronautTest(transactional = false)
+class ProjectControllerSpec extends Specification{
+
+    @Inject
+    ApplicationContext applicationContext
+
+    @Inject
+    EmbeddedServer embeddedServer
+
+    @Inject
+    @Client('/')
+    Rx3HttpClient httpClient
+
+    def "verify ProjectController bean exists"() {
+        given:
+        applicationContext
+
+        expect:
+        applicationContext.containsBean(ProjectController)
+    }
+
+    @Unroll
+    void "should be reachable and return one project"() {
+        when:
+        HttpResponse response = httpClient.toBlocking().exchange("/projects", List)
+
+        then:
+        response.status == HttpStatus.OK
+        response.body().size() == 1
+    }
+
+    @Unroll
+    void "should return Http 200 for given case identifier if available "() {
+        when:
+        HttpResponse response = httpClient.toBlocking().exchange("/projects/${identifier}")
+
+        then:
+        response.status == status
+
+        where:
+        identifier || status
+        "PROJ"   ||   HttpStatus.OK
+    }
+
+    @Unroll
+    void "should return Http 404 for given case identifier if not available "() {
+        when:
+        def identifier = "PROJ2"
+        httpClient.toBlocking().exchange("/projects/${identifier}", HttpResponse)
+
+        then:
+        HttpClientResponseException t = thrown(HttpClientResponseException)
+        t.getStatus().code == 404
+    }
+}

--- a/src/test/resources/db-test/mariadb/V1__variantstore_test_db.sql
+++ b/src/test/resources/db-test/mariadb/V1__variantstore_test_db.sql
@@ -860,9 +860,12 @@ CREATE TABLE `project`
 LOCK TABLES `project` WRITE;
 /*!40000 ALTER TABLE `project`
     DISABLE KEYS */;
+INSERT INTO `project`
+VALUES ( 'PROJ');
 /*!40000 ALTER TABLE `project`
     ENABLE KEYS */;
 UNLOCK TABLES;
+
 
 --
 -- Table structure for table `referencegenome`


### PR DESCRIPTION
This adds
- an endpoint/controller for `Project`
- functions on service layer
- function on the database interfaces to retrieve projects (by identifier/ all)
- tests for the project-specific endpoint